### PR TITLE
Bytes type and coverall test fixture

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1449,7 +1449,7 @@ checksum = "0336d538f7abc86d282a4189614dfaa90810dfc2c6f6427eaf88e16311dd225d"
 [[package]]
 name = "uniffi"
 version = "0.28.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?branch=main#cd38ccea8236df7d93aff336c325a3a8e524af5d"
+source = "git+https://github.com/mozilla/uniffi-rs.git?branch=main#bfa98ed377629de931587cf412692f4388ca9471"
 dependencies = [
  "anyhow",
  "camino",
@@ -1483,6 +1483,7 @@ dependencies = [
  "uniffi-example-futures",
  "uniffi-example-geometry",
  "uniffi-example-rondpoint",
+ "uniffi-fixture-coverall",
  "uniffi-fixture-futures",
  "uniffi-fixture-time",
  "uniffi_bindgen",
@@ -1493,7 +1494,7 @@ dependencies = [
 [[package]]
 name = "uniffi-example-arithmetic"
 version = "0.22.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?branch=main#cd38ccea8236df7d93aff336c325a3a8e524af5d"
+source = "git+https://github.com/mozilla/uniffi-rs.git?branch=main#bfa98ed377629de931587cf412692f4388ca9471"
 dependencies = [
  "thiserror",
  "uniffi",
@@ -1502,7 +1503,7 @@ dependencies = [
 [[package]]
 name = "uniffi-example-custom-types"
 version = "0.22.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?branch=main#cd38ccea8236df7d93aff336c325a3a8e524af5d"
+source = "git+https://github.com/mozilla/uniffi-rs.git?branch=main#bfa98ed377629de931587cf412692f4388ca9471"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1513,7 +1514,7 @@ dependencies = [
 [[package]]
 name = "uniffi-example-futures"
 version = "0.22.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?branch=main#cd38ccea8236df7d93aff336c325a3a8e524af5d"
+source = "git+https://github.com/mozilla/uniffi-rs.git?branch=main#bfa98ed377629de931587cf412692f4388ca9471"
 dependencies = [
  "async-std",
  "thiserror",
@@ -1523,7 +1524,7 @@ dependencies = [
 [[package]]
 name = "uniffi-example-geometry"
 version = "0.22.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?branch=main#cd38ccea8236df7d93aff336c325a3a8e524af5d"
+source = "git+https://github.com/mozilla/uniffi-rs.git?branch=main#bfa98ed377629de931587cf412692f4388ca9471"
 dependencies = [
  "uniffi",
 ]
@@ -1531,15 +1532,25 @@ dependencies = [
 [[package]]
 name = "uniffi-example-rondpoint"
 version = "0.22.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?branch=main#cd38ccea8236df7d93aff336c325a3a8e524af5d"
+source = "git+https://github.com/mozilla/uniffi-rs.git?branch=main#bfa98ed377629de931587cf412692f4388ca9471"
 dependencies = [
+ "uniffi",
+]
+
+[[package]]
+name = "uniffi-fixture-coverall"
+version = "0.22.0"
+source = "git+https://github.com/mozilla/uniffi-rs.git?branch=main#bfa98ed377629de931587cf412692f4388ca9471"
+dependencies = [
+ "once_cell",
+ "thiserror",
  "uniffi",
 ]
 
 [[package]]
 name = "uniffi-fixture-futures"
 version = "0.21.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?branch=main#cd38ccea8236df7d93aff336c325a3a8e524af5d"
+source = "git+https://github.com/mozilla/uniffi-rs.git?branch=main#bfa98ed377629de931587cf412692f4388ca9471"
 dependencies = [
  "async-trait",
  "futures",
@@ -1552,7 +1563,7 @@ dependencies = [
 [[package]]
 name = "uniffi-fixture-time"
 version = "0.22.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?branch=main#cd38ccea8236df7d93aff336c325a3a8e524af5d"
+source = "git+https://github.com/mozilla/uniffi-rs.git?branch=main#bfa98ed377629de931587cf412692f4388ca9471"
 dependencies = [
  "chrono",
  "thiserror",
@@ -1562,7 +1573,7 @@ dependencies = [
 [[package]]
 name = "uniffi_bindgen"
 version = "0.28.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?branch=main#cd38ccea8236df7d93aff336c325a3a8e524af5d"
+source = "git+https://github.com/mozilla/uniffi-rs.git?branch=main#bfa98ed377629de931587cf412692f4388ca9471"
 dependencies = [
  "anyhow",
  "askama",
@@ -1585,7 +1596,7 @@ dependencies = [
 [[package]]
 name = "uniffi_build"
 version = "0.28.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?branch=main#cd38ccea8236df7d93aff336c325a3a8e524af5d"
+source = "git+https://github.com/mozilla/uniffi-rs.git?branch=main#bfa98ed377629de931587cf412692f4388ca9471"
 dependencies = [
  "anyhow",
  "camino",
@@ -1595,7 +1606,7 @@ dependencies = [
 [[package]]
 name = "uniffi_checksum_derive"
 version = "0.28.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?branch=main#cd38ccea8236df7d93aff336c325a3a8e524af5d"
+source = "git+https://github.com/mozilla/uniffi-rs.git?branch=main#bfa98ed377629de931587cf412692f4388ca9471"
 dependencies = [
  "quote",
  "syn",
@@ -1604,7 +1615,7 @@ dependencies = [
 [[package]]
 name = "uniffi_core"
 version = "0.28.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?branch=main#cd38ccea8236df7d93aff336c325a3a8e524af5d"
+source = "git+https://github.com/mozilla/uniffi-rs.git?branch=main#bfa98ed377629de931587cf412692f4388ca9471"
 dependencies = [
  "anyhow",
  "async-compat",
@@ -1619,7 +1630,7 @@ dependencies = [
 [[package]]
 name = "uniffi_macros"
 version = "0.28.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?branch=main#cd38ccea8236df7d93aff336c325a3a8e524af5d"
+source = "git+https://github.com/mozilla/uniffi-rs.git?branch=main#bfa98ed377629de931587cf412692f4388ca9471"
 dependencies = [
  "bincode",
  "camino",
@@ -1636,7 +1647,7 @@ dependencies = [
 [[package]]
 name = "uniffi_meta"
 version = "0.28.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?branch=main#cd38ccea8236df7d93aff336c325a3a8e524af5d"
+source = "git+https://github.com/mozilla/uniffi-rs.git?branch=main#bfa98ed377629de931587cf412692f4388ca9471"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1647,7 +1658,7 @@ dependencies = [
 [[package]]
 name = "uniffi_testing"
 version = "0.28.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?branch=main#cd38ccea8236df7d93aff336c325a3a8e524af5d"
+source = "git+https://github.com/mozilla/uniffi-rs.git?branch=main#bfa98ed377629de931587cf412692f4388ca9471"
 dependencies = [
  "anyhow",
  "camino",
@@ -1659,7 +1670,7 @@ dependencies = [
 [[package]]
 name = "uniffi_udl"
 version = "0.28.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?branch=main#cd38ccea8236df7d93aff336c325a3a8e524af5d"
+source = "git+https://github.com/mozilla/uniffi-rs.git?branch=main#bfa98ed377629de931587cf412692f4388ca9471"
 dependencies = [
  "anyhow",
  "textwrap",
@@ -1794,7 +1805,7 @@ dependencies = [
 [[package]]
 name = "weedle2"
 version = "5.0.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?branch=main#cd38ccea8236df7d93aff336c325a3a8e524af5d"
+source = "git+https://github.com/mozilla/uniffi-rs.git?branch=main#bfa98ed377629de931587cf412692f4388ca9471"
 dependencies = [
  "nom",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ uniffi-example-custom-types = { git = "https://github.com/mozilla/uniffi-rs.git"
 uniffi-example-futures = { git = "https://github.com/mozilla/uniffi-rs.git", branch = "main" }
 uniffi-example-geometry = { git = "https://github.com/mozilla/uniffi-rs.git", branch = "main" }
 uniffi-example-rondpoint = { git = "https://github.com/mozilla/uniffi-rs.git", branch = "main" }
+uniffi-fixture-coverall = { git = "https://github.com/mozilla/uniffi-rs.git", branch = "main" }
 uniffi-fixture-futures = { git = "https://github.com/mozilla/uniffi-rs.git", branch = "main" }
 uniffi-fixture-time = { git = "https://github.com/mozilla/uniffi-rs.git", branch = "main" }
 uniffi_testing = { git = "https://github.com/mozilla/uniffi-rs.git", branch = "main" }

--- a/src/gen_java/mod.rs
+++ b/src/gen_java/mod.rs
@@ -522,7 +522,7 @@ impl AsCodeType for Type {
             Type::Float64 => Box::new(primitives::Float64CodeType),
             Type::Boolean => Box::new(primitives::BooleanCodeType),
             Type::String => Box::new(primitives::StringCodeType),
-            Type::Bytes => unimplemented!(), //Box::new(primitives::BytesCodeType),
+            Type::Bytes => Box::new(primitives::BytesCodeType),
 
             Type::Timestamp => Box::new(miscellany::TimestampCodeType),
             Type::Duration => Box::new(miscellany::DurationCodeType),

--- a/src/gen_java/primitives.rs
+++ b/src/gen_java/primitives.rs
@@ -75,6 +75,22 @@ macro_rules! impl_code_type_for_primitive {
     };
 }
 
+#[derive(Debug)]
+pub struct BytesCodeType;
+impl CodeType for BytesCodeType {
+    fn type_label(&self, _ci: &ComponentInterface) -> String {
+        "byte[]".to_string()
+    }
+
+    fn canonical_name(&self) -> String {
+        "ByteArray".to_string()
+    }
+
+    fn literal(&self, literal: &Literal, ci: &ComponentInterface) -> String {
+        render_literal(&literal, ci)
+    }
+}
+
 impl_code_type_for_primitive!(BooleanCodeType, "Boolean");
 impl_code_type_for_primitive!(StringCodeType, "String");
 impl_code_type_for_primitive!(Int8CodeType, "Byte");

--- a/src/templates/ByteArrayHelper.java
+++ b/src/templates/ByteArrayHelper.java
@@ -1,0 +1,26 @@
+package {{ config.package_name() }};
+
+import java.nio.ByteBuffer;
+
+public enum FfiConverterByteArray implements FfiConverterRustBuffer<byte[]>{
+  INSTANCE;
+
+    @Override
+    public byte[] read(ByteBuffer buf) {
+        int len = buf.getInt();
+        byte[] byteArr = new byte[len];
+        buf.get(byteArr);
+        return byteArr;
+    }
+  
+    @Override
+    public long allocationSize(byte[] value) {
+        return 4L + (long)value.length;
+    }
+
+    @Override
+    public void write(byte[] value, ByteBuffer buf) {
+        buf.putInt(value.length);
+        buf.put(value);
+    }
+}

--- a/src/templates/EnumTemplate.java
+++ b/src/templates/EnumTemplate.java
@@ -57,14 +57,14 @@ public enum {{ e|ffi_converter_name}} implements FfiConverterRustBuffer<{{ type_
 {% else %}
 
 {%- call java::docstring(e, 0) %}
-public sealed interface {{ type_name }}{% if contains_object_references %} extends Disposable {% endif %} {
+public sealed interface {{ type_name }}{% if contains_object_references %} extends AutoCloseable {% endif %} {
   {% for variant in e.variants() -%}
   {%- call java::docstring(variant, 4) %}
   {% if !variant.has_fields() -%}
   record {{ variant|type_name(ci)}}() implements {{ type_name }} {
     {% if contains_object_references %}
     @Override
-    public void destroy() {
+    public void close() {
       // Nothing to destroy
     }
     {% endif %}
@@ -78,7 +78,7 @@ public sealed interface {{ type_name }}{% if contains_object_references %} exten
   ) implements {{ type_name }} {
     {% if contains_object_references %}
     @Override
-    public void destroy() {
+    public void close() {
       {% call java::destroy_fields(variant) %}
     }
     {% endif %}

--- a/src/templates/Helpers.java
+++ b/src/templates/Helpers.java
@@ -131,6 +131,7 @@ public final class UniffiHelpers {
       try {
           writeReturn.accept(makeCall.get());
       } catch (Exception e) {
+          System.out.println(e);
           callStatus.setCode(UniffiRustCallStatus.UNIFFI_CALL_UNEXPECTED_ERROR);
           callStatus.setErrorBuf({{ Type::String.borrow()|lower_fn }}(e.toString()));
       }
@@ -146,7 +147,7 @@ public final class UniffiHelpers {
       try {
           writeReturn.accept(makeCall.call());
       } catch (Exception e) {
-          if (e.getClass().isAssignableFrom(errorClazz)) {
+          if (errorClazz.isAssignableFrom(e.getClass())) {
               @SuppressWarnings("unchecked")
               E castedE = (E) e;
               callStatus.setCode(UniffiRustCallStatus.UNIFFI_CALL_ERROR);

--- a/src/templates/Helpers.java
+++ b/src/templates/Helpers.java
@@ -131,7 +131,6 @@ public final class UniffiHelpers {
       try {
           writeReturn.accept(makeCall.get());
       } catch (Exception e) {
-          System.out.println(e);
           callStatus.setCode(UniffiRustCallStatus.UNIFFI_CALL_UNEXPECTED_ERROR);
           callStatus.setErrorBuf({{ Type::String.borrow()|lower_fn }}(e.toString()));
       }

--- a/src/templates/Interface.java
+++ b/src/templates/Interface.java
@@ -3,11 +3,13 @@ package {{ config.package_name() }};
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import com.sun.jna.*;
+import com.sun.jna.ptr.*;
 
 {%- call java::docstring_value(interface_docstring, 0) %}
 public interface {{ interface_name }} {
     {% for meth in methods.iter() -%}
     {%- call java::docstring(meth, 4) %}
-    public {% if meth.is_async() %}CompletableFuture<{% endif %}{% match meth.return_type() -%}{%- when Some with (return_type) %}{{ return_type|type_name(ci) }}{%- else -%}Void{%- endmatch %}{% if meth.is_async() %}>{% endif %} {{ meth.name()|fn_name }}({% call java::arg_list(meth, true) %});
+    public {% if meth.is_async() %}CompletableFuture<{% endif %}{% match meth.return_type() -%}{%- when Some with (return_type) %}{{ return_type|type_name(ci) }}{%- else -%}{% if meth.is_async() %}Void{% else %}void{% endif %}{%- endmatch %}{% if meth.is_async() %}>{% endif %} {{ meth.name()|fn_name }}({% call java::arg_list(meth, true) %}){% match meth.throws_type() %}{% when Some(throwable) %} {% if !meth.is_async() %}throws {{ throwable|type_name(ci) }}{% endif %}{% else %}{% endmatch %};
     {% endfor %}
 }

--- a/src/templates/NamespaceLibraryTemplate.java
+++ b/src/templates/NamespaceLibraryTemplate.java
@@ -41,7 +41,8 @@ final class NamespaceLibrary {
 {%- when FfiDefinition::CallbackFunction(callback) %}
 package {{ config.package_name() }};
 
-import com.sun.jna.Callback;
+import com.sun.jna.*;
+import com.sun.jna.ptr.*;
 
 interface {{ callback.name()|ffi_callback_name }} extends Callback {
     public {% match callback.return_type() %}{%- when Some(return_type) %}{{ return_type|ffi_type_name_for_ffi_struct }}{%- when None %}void{%- endmatch %} callback(

--- a/src/templates/ObjectTemplate.java
+++ b/src/templates/ObjectTemplate.java
@@ -115,6 +115,7 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Function;
+import java.util.function.Consumer;
 import com.sun.jna.Pointer;
 import java.util.concurrent.CompletableFuture;
 
@@ -151,7 +152,7 @@ public class {{ impl_class_name }} implements Disposable, AutoCloseable, {{ inte
   // Note no constructor generated for this object as it is async.
   {%-     else %}
   {%- call java::docstring(cons, 4) %}
-  public {{ impl_class_name }}({% call java::arg_list(cons, true) -%}){
+  public {{ impl_class_name }}({% call java::arg_list(cons, true) -%}) {% match cons.throws_type() %}{% when Some(throwable) %}throws {{ throwable|type_name(ci) }}{% else %}{% endmatch %}{
     this((Pointer){%- call java::to_ffi_call(cons) -%});
   }
   {%-     endif %}
@@ -197,6 +198,13 @@ public class {{ impl_class_name }} implements Disposable, AutoCloseable, {{ inte
           cleanable.clean();
       }
     }
+  }
+
+  public void callWithPointer(Consumer<Pointer> block) {
+    callWithPointer((Pointer p) -> {
+      block.accept(p);
+      return (Void)null;
+    });
   }
 
   private class UniffiCleanAction implements Runnable {

--- a/src/templates/RecordTemplate.java
+++ b/src/templates/RecordTemplate.java
@@ -15,16 +15,16 @@ public record {{ type_name }}(
     {{ field|type_name(ci) }} {{ field.name()|var_name -}}
     {% if !loop.last %}, {% endif %}
     {%- endfor %}
-) {% if contains_object_references %} implements Disposable {% endif %}{
-{% if contains_object_references %}
+) {% if contains_object_references %}implements AutoCloseable {% endif %}{
+    {% if contains_object_references %}
     @Override
-    public void destroy() {
+    public void close() {
         {% call java::destroy_fields(rec) %}
     }
     {% endif %}
 }
 {% else %}
-public class {{ type_name }} {
+public class {{ type_name }} {% if contains_object_references %}implements AutoCloseable {% endif %}{
     {%- for field in rec.fields() %}
     {%- call java::docstring(field, 4) %}
     private {{ field|type_name(ci) }} {{ field.name()|var_name -}};
@@ -55,6 +55,13 @@ public class {{ type_name }} {
         this.{{ field_var_name }} = {{ field_var_name }};
     }
     {%- endfor %}
+
+    {% if contains_object_references %}
+    @Override
+    public void close() {
+        {% call java::destroy_fields(rec) %}
+    }
+    {% endif %}
     
     @Override
     public boolean equals(Object other) {

--- a/src/templates/RecordTemplate.java
+++ b/src/templates/RecordTemplate.java
@@ -75,7 +75,7 @@ public class {{ type_name }} {
     }
 }
 {% endif %}
-{%- else -%}
+{%- else %}
 public class {{ type_name }} {
     @Override
     public boolean equals(Object other) {

--- a/src/templates/RustBufferTemplate.java
+++ b/src/templates/RustBufferTemplate.java
@@ -17,6 +17,12 @@ public class RustBuffer extends Structure {
     public static class ByValue extends RustBuffer implements Structure.ByValue {}
     public static class ByReference extends RustBuffer implements Structure.ByReference {}
 
+    void setValue(RustBuffer other) {
+        this.capacity = other.capacity;
+        this.len = other.len;
+        this.data = other.data;
+    }
+
     public static RustBuffer.ByValue alloc(long size) {
         RustBuffer.ByValue buffer = UniffiHelpers.uniffiRustCall((UniffiRustCallStatus status) -> {
             return (RustBuffer.ByValue) UniffiLib.INSTANCE.{{ ci.ffi_rustbuffer_alloc().name() }}(size, status);
@@ -68,6 +74,19 @@ public class RustBufferByReference extends Structure implements Structure.ByRefe
         pointer.setInt(0, (int) value.capacity);
         pointer.setInt(4, (int) value.len);
         pointer.setPointer(8, value.data);
+    }
+
+    /**
+     * Get a `RustBuffer.ByValue` from this reference.
+     */
+    public RustBuffer.ByValue getValue() {
+        Pointer pointer = this.getPointer();
+        RustBuffer.ByValue value = new RustBuffer.ByValue();
+        value.writeField("capacity", pointer.getLong(0));
+        value.writeField("len", pointer.getLong(8));
+        value.writeField("data", pointer.getLong(16));
+
+        return value;
     }
 }
 

--- a/src/templates/Types.java
+++ b/src/templates/Types.java
@@ -4,32 +4,18 @@ package {{ config.package_name() }};
 
 import java.util.stream.Stream;
 
-public interface Disposable {
-    void destroy();
-
-    static void destroy(Object... args) {
+public interface AutoCloseableHelper {
+    static void close(Object... args) {
         Stream.of(args)
-              .filter(Disposable.class::isInstance)
-              .map(Disposable.class::cast)
-              .forEach(disposable -> {disposable.destroy();} );
-    }
-}
-
-package {{ config.package_name() }};
-
-public class DisposableHelper {
-    public static <T extends Disposable, R> R use(T disposable, java.util.function.Function<T, R> block) {
-        try {
-            return block.apply(disposable);
-        } finally {
-            try {
-                if (disposable != null) {
-                    disposable.destroy();
-                }
-            } catch (Throwable ignored) {
-                // swallow
-            }
-        }
+              .filter(AutoCloseable.class::isInstance)
+              .map(AutoCloseable.class::cast)
+              .forEach(closable -> { 
+                  try {
+                      closable.close();
+                  } catch (Exception e) {
+                      throw new RuntimeException(e);
+                  }
+              });
     }
 }
 

--- a/src/templates/Types.java
+++ b/src/templates/Types.java
@@ -64,8 +64,9 @@ public class NoPointer {
 {%- when Type::Boolean %}
 {%- include "BooleanHelper.java" %}
 
-// TODO(murph): this isn't being called for the futures fixture test. Why? Tried a random Canary class instead of the
-// full thing but it doesn't show up. The method interfaces and other things _are_ being generated.
+{%- when Type::Bytes %}
+{%- include "ByteArrayHelper.java" %}
+
 {%- when Type::CallbackInterface { module_path, name } %}
 {% include "CallbackInterfaceTemplate.java" %}
 
@@ -123,9 +124,6 @@ public class NoPointer {
 {% include "TimestampHelper.java" %}
 
 {# TODO(murph): implement the rest of the types
-
-{%- when Type::Bytes %}
-{%- include "ByteArrayHelper.kt" %}
 
 {%- when Type::External { module_path, name, namespace, kind, tagged } %}
 {% include "ExternalTypeTemplate.kt" %}

--- a/src/templates/macros.java
+++ b/src/templates/macros.java
@@ -6,9 +6,17 @@
 
 {%- macro to_ffi_call(func) -%}
     {%- if func.takes_self() %}
-    callWithPointer(it ->
-        {%- call to_raw_ffi_call(func) %}
-    )
+    callWithPointer(it -> {
+        try {
+    {% if func.return_type().is_some() %}
+            return {%- call to_raw_ffi_call(func) %};
+    {% else %}
+            {%- call to_raw_ffi_call(func) %};
+    {% endif %}
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    })
     {% else %}
         {%- call to_raw_ffi_call(func) %}
     {% endif %}
@@ -21,7 +29,7 @@
     {%- else %}
     UniffiHelpers.uniffiRustCall(
     {%- endmatch %} _status -> {
-        return UniffiLib.INSTANCE.{{ func.ffi_func().name() }}(
+        {% if func.return_type().is_some() %}return {% endif %}UniffiLib.INSTANCE.{{ func.ffi_func().name() }}(
             {% if func.takes_self() %}it, {% endif -%}
             {% if func.arguments().len() != 0 %}{% call arg_list_lowered(func) -%}, {% endif -%}
             _status);
@@ -47,7 +55,8 @@
         throws {{ throwable|type_name(ci) }}
         {%-     else -%}
         {%- endmatch %} {
-            return {% match callable.return_type() -%}{%- when Some with (return_type) -%}{{ return_type|lift_fn }}{%- when None %}{%- endmatch %}({% call to_ffi_call(callable) %});
+            // TODO(murph): to_ffi_call(callable) may throw `callable.throws_type` in a RuntimeException because Java closures can't throw. Now that we're in something declaring that throw we should re-catch it and throw it again
+            {% match callable.return_type() -%}{%- when Some with (return_type) -%}return {{ return_type|lift_fn }}({% call to_ffi_call(callable) %}){%- when None %}{% call to_ffi_call(callable) %}{%- endmatch %};
     }
     {% endif %}
 {% endmacro %}
@@ -55,12 +64,12 @@
 {%- macro call_async(callable) -%}
     UniffiAsyncHelpers.uniffiRustCallAsync(
 {%- if callable.takes_self() %}
-        callWithPointer(thisPtr ->
-            UniffiLib.INSTANCE.{{ callable.ffi_func().name() }}(
+        callWithPointer(thisPtr -> {
+            return UniffiLib.INSTANCE.{{ callable.ffi_func().name() }}(
                 thisPtr{% if callable.arguments().len() != 0 %},{% endif %}
                 {% call arg_list_lowered(callable) %}
-            )
-        ),
+            );
+        }),
 {%- else %}
         UniffiLib.INSTANCE.{{ callable.ffi_func().name() }}({% call arg_list_lowered(callable) %}),
 {%- endif %}
@@ -128,7 +137,7 @@ v{{- field_num -}}
     Disposable.destroy(
     {%- for field in member.fields() %}
         this.{{ field.name()|var_name }}{%- if !loop.last %}, {% endif -%}
-    {% endfor -%})
+    {% endfor -%});
 {%- endmacro -%}
 
 {%- macro docstring_value(maybe_docstring, indent_spaces) %}

--- a/tests/fixtures.rs
+++ b/tests/fixtures.rs
@@ -311,7 +311,7 @@ fixture_tests! {
     (test_rondpoint, "uniffi-example-rondpoint", "scripts/TestRondpoint.java"),
     // (test_todolist, "uniffi-example-todolist", "scripts/test_todolist.java"),
     // (test_sprites, "uniffi-example-sprites", "scripts/test_sprites.java"),
-    // (test_coverall, "uniffi-fixture-coverall", "scripts/test_coverall.java"),
+    (test_coverall, "uniffi-fixture-coverall", "scripts/TestFixtureCoverall.java"),
     (test_chronological, "uniffi-fixture-time", "scripts/TestChronological.java"),
     (test_custom_types, "uniffi-example-custom-types", "scripts/TestCustomTypes/TestCustomTypes.java"),
     // (test_callbacks, "uniffi-fixture-callbacks", "scripts/test_callbacks.java"),

--- a/tests/scripts/TestFixtureCoverall.java
+++ b/tests/scripts/TestFixtureCoverall.java
@@ -4,15 +4,543 @@
 
 import uniffi.coverall.*;
 
+import java.nio.charset.StandardCharsets;
 import java.time.Instant;
+import java.util.Arrays;
+import java.util.List;
 import java.util.concurrent.*;
+import java.lang.ref.WeakReference;
+import java.text.MessageFormat;
 
 public class TestFixtureCoverall {
+  public static boolean almostEquals(float a, float b) {
+    return Math.abs(a - b) < .000001f;
+  }
+  public static boolean almostEquals(double a, double b) {
+    return Math.abs(a - b) < .000001d;
+  }
+  // Test traits from Java.
+  static void testGettersFromJava(Getters getters) {
+    assert getters.getBool(true, true) == false;
+    assert getters.getBool(true, false) == true;
+    assert getters.getBool(false, true) == true;
+    assert getters.getBool(false, false) == false;
+
+    try {
+      assert getters.getString("hello", false).equals("hello");
+      assert getters.getString("hello", true).equals("HELLO");
+    } catch (CoverallException e) {
+      throw new RuntimeException("Unexpected CoverallException", e);
+    }
+
+    try {
+      assert getters.getOption("hello", true).equals("HELLO");
+      assert getters.getOption("hello", false).equals("hello");
+      assert getters.getOption("", true) == null;
+    } catch (ComplexException e) {
+      throw new RuntimeException("Unexpected ComplexException", e);
+    }
+
+    assert getters.getList(Arrays.asList(1, 2, 3), true).equals(Arrays.asList(1, 2, 3));
+    assert getters.getList(Arrays.asList(1, 2, 3), false).equals(Arrays.asList());
+
+    // void function returns nothing, compiler won't let us write this test
+    // assert getters.getNothing("hello") == Unit;
+
+    try {
+      getters.getString("too-many-holes", true);
+      throw new RuntimeException("Expected method to throw exception");
+    } catch (CoverallException.TooManyHoles e) {
+      // Expected
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+
+    try {
+      getters.getOption("os-error", true);
+      throw new RuntimeException("Expected method to throw exception");
+    } catch (ComplexException.OsException e) {
+      assert e.code().intValue() == 100;
+      assert e.extendedCode().intValue() == 200;
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+
+    try {
+      getters.getOption("unknown-error", true);
+      throw new RuntimeException("Expected method to throw exception");
+    } catch (ComplexException.UnknownException e) {
+      // Expected
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+
+    try {
+      getters.getString("unexpected-error", true);
+    } catch (Exception e) {
+      // Expected
+    } 
+  }
+
   public static void main(String[] args) throws Exception {
     // Test some_dict()
-    {
-      var d = Coverall.createSomeDict();
+    try (var d = Coverall.createSomeDict()) {
       assert d.text().equals("text");
+      assert d.maybeText().equals("maybe_text");
+      assert Arrays.equals(d.someBytes(), "some_bytes".getBytes(StandardCharsets.UTF_8));
+      assert Arrays.equals(d.maybeSomeBytes(), "maybe_some_bytes".getBytes(StandardCharsets.UTF_8));
+      assert d.aBool();
+      assert d.maybeABool() == false;
+      assert d.unsigned8() == (byte)1;
+      assert d.maybeUnsigned8() == (byte)2;
+      assert d.unsigned16() == (short)3;
+      assert d.maybeUnsigned16() == (short)4;
+      assert d.unsigned64() == Long.parseUnsignedLong("18446744073709551615");
+      assert d.maybeUnsigned64() == 0L;
+      assert d.signed8() == (byte)8;
+      assert d.maybeSigned8() == (byte)0;
+      assert d.signed64() == 9223372036854775807L;
+      assert d.maybeSigned64() == 0L;
+
+      // floats should be "close enough".
+      assert almostEquals(d.float32(), 1.2345F);
+      assert almostEquals(d.maybeFloat32(), 22.0F/7.0F);
+      assert almostEquals(d.float64(), 0.0);
+      assert almostEquals(d.maybeFloat64(), 1.0);
+
+      assert d.coveralls().getName().equals("some_dict");
+    }
+    
+    try (var d = Coverall.createNoneDict()) {
+      assert d.text().equals("text");
+      assert d.maybeText() == null;
+      assert Arrays.equals(d.someBytes(), "some_bytes".getBytes(StandardCharsets.UTF_8));
+      assert d.maybeSomeBytes() == null;
+      assert d.aBool();
+      assert d.maybeABool() == null;
+      assert d.unsigned8() == (byte) 1;
+      assert d.maybeUnsigned8() == null;
+      assert d.unsigned16() == (short) 3;
+      assert d.maybeUnsigned16() == null;
+      assert d.unsigned64() == Long.parseUnsignedLong("18446744073709551615");
+      assert d.maybeUnsigned64() == null;
+      assert d.signed8() == (byte) 8;
+      assert d.maybeSigned8() == null;
+      assert d.signed64() == 9223372036854775807L;
+      assert d.maybeSigned64() == null;
+
+      // floats should be "close enough".
+      assert almostEquals(d.float32(), 1.2345F);
+      assert d.maybeFloat32() == null;
+      assert almostEquals(d.float64(), 0.0);
+      assert d.maybeFloat64() == null;
+
+      assert d.coveralls() == null;
+    }
+    
+    // Test arcs.
+    try (var coveralls = new Coveralls("test_arcs")) {
+      assert Coverall.getNumAlive() == 1;
+      // One ref held by the foreign-language code, one created for this method call.
+      assert coveralls.strongCount() == 2;
+      assert coveralls.getOther() == null;
+      coveralls.takeOther(coveralls);
+      // Should now be a new strong ref, held by the object's reference to itself.
+      assert coveralls.strongCount() == 3;
+      // But the same number of instances.
+      assert Coverall.getNumAlive() == 1;
+      // Careful, this makes a new Java object which must be separately destroyed.
+      try (Coveralls other = coveralls.getOther()) {
+        // It's the same Rust object.
+        assert other.getName().equals("test_arcs");
+      }
+      try {
+        coveralls.takeOtherFallible();
+        throw new RuntimeException("Should have thrown an IntegerOverflow exception!");
+      } catch (CoverallException.TooManyHoles e) {
+        // It's okay!
+      }
+      try {
+        coveralls.takeOtherPanic("expected panic: with an arc!");
+        throw new RuntimeException("Should have thrown an InternalException!");
+      } catch (InternalException e) {
+        // No problemo!
+      }
+
+      try {
+        coveralls.falliblePanic("Expected panic in a fallible function!");
+        throw new RuntimeException("Should have thrown an InternalException");
+      } catch (InternalException e) {
+        // No problemo!
+      }
+      coveralls.takeOther(null);
+      assert coveralls.strongCount() == 2;
+    }
+    assert Coverall.getNumAlive() == 0;
+    
+    // Test return objects.
+    try (var coveralls = new Coveralls("test_return_objects")) {
+      assert Coverall.getNumAlive() == 1;
+      assert coveralls.strongCount() == 2;
+      try (Coveralls c2 = coveralls.cloneMe()) {
+        assert c2.getName().equals(coveralls.getName());
+        assert Coverall.getNumAlive() == 2;
+        assert c2.strongCount() == 2;
+
+        coveralls.takeOther(c2);
+        // same number alive but `c2` has an additional ref count.
+        assert Coverall.getNumAlive() == 2;
+        assert coveralls.strongCount() == 2;
+        assert c2.strongCount() == 3;
+      }
+      // Here we've dropped Java's reference to `c2`, but the rust struct will not
+      // be dropped as coveralls hold an `Arc<>` to it.
+      assert Coverall.getNumAlive() == 2;
+    }
+    // Destroying `coveralls` will kill both.
+    assert Coverall.getNumAlive() == 0;
+    
+    // Test simple errors.
+    try (var coveralls = new Coveralls("test_simple_errors")) {
+      try {
+        coveralls.maybeThrow(true);
+        throw new RuntimeException("Expected method to throw exception");
+      } catch (CoverallException.TooManyHoles e) {
+        // Expected result
+        assert e.getMessage().equals("The coverall has too many holes");
+      }
+
+      try {
+        coveralls.maybeThrowInto(true);
+        throw new RuntimeException("Expected method to throw exception");
+      } catch (CoverallException.TooManyHoles e) {
+        // Expected result
+      }
+
+      try {
+        coveralls.panic("oops");
+        throw new RuntimeException("Expected method to throw exception");
+      } catch (InternalException e) {
+        // Expected result
+        assert e.getMessage().equals("oops");
+      }
+    }
+    
+    // Test complex errors.
+    try (var coveralls = new Coveralls("test_complex_errors")) {
+      assert coveralls.maybeThrowComplex((byte)0);
+
+      try {
+        coveralls.maybeThrowComplex((byte)1);
+        throw new RuntimeException("Expected method to throw exception");
+      } catch (ComplexException.OsException e) {
+        assert e.code() == 10;
+        assert e.extendedCode() == 20;
+        assert e.toString().equals("uniffi.coverall.ComplexException$OsException: code=10, extendedCode=20");
+      }
+
+      try {
+        coveralls.maybeThrowComplex((byte)2);
+        throw new RuntimeException("Expected method to throw exception");
+      } catch (ComplexException.PermissionDenied e) {
+        assert e.reason().equals("Forbidden");
+        assert e.toString().equals("uniffi.coverall.ComplexException$PermissionDenied: reason=Forbidden");
+      }
+
+      try {
+        coveralls.maybeThrowComplex((byte)3);
+        throw new RuntimeException("Expected method to throw exception");
+      } catch (ComplexException.UnknownException e) {
+        assert e.toString().equals("uniffi.coverall.ComplexException$UnknownException: ");
+      }
+
+      try {
+        coveralls.maybeThrowComplex((byte)4);
+        throw new RuntimeException("Expected method to throw exception");
+      } catch (InternalException e) {
+        // Expected result
+      }
+    }
+    
+    // Test error values.
+    try (var coveralls = new Coveralls("test_error_values")) {
+      try {
+        Coverall.throwRootError();
+        throw new RuntimeException("Expected method to throw exception");
+      } catch (RootException.Complex e) {
+        assert e.error() instanceof ComplexException.OsException;
+      }
+
+      RootException e = Coverall.getRootError();
+      if (e instanceof RootException.Other) {
+        assert ((RootException.Other) e).error() == OtherError.UNEXPECTED;
+      } else {
+        throw new RuntimeException("Unexpected error subclass");
+      }
+
+      ComplexException ce = Coverall.getComplexError(null);
+      assert ce instanceof ComplexException.PermissionDenied;
+
+      assert Coverall.getErrorDict(null).complexError() == null;
+    }
+    
+    // Test interfaces in dicts.
+    try (Coveralls coveralls = new Coveralls("test_interfaces_in_dicts")) {
+      coveralls.addPatch(new Patch(Color.RED));
+      coveralls.addRepair(new Repair(Instant.now(), new Patch(Color.BLUE)));
+      assert coveralls.getRepairs().size() == 2;
+    }
+    
+    // Test regressions.
+    try (Coveralls coveralls = new Coveralls("test_regressions")) {
+      assert coveralls.getStatus("success").equals("status: success");
+    }
+    
+    // Test empty records.
+    try (Coveralls coveralls = new Coveralls("test_empty_records")) {
+      assert coveralls.setAndGetEmptyStruct(new EmptyStruct()).equals(new EmptyStruct());
+      assert new EmptyStruct() != new EmptyStruct();
+    }
+    
+    // The GC test; we should have 1000 alive by the end of the loop.
+    //
+    // Later on, nearer the end of the script, we'll test again, when the cleaner
+    // has had time to clean up.
+    //
+    // The number alive then should be zero.
+    // First we make 1000 objects, and wait for the rest of the test to run. If it has, then
+    // the garbage objects have been collected, and the Rust counter parts have been dropped.
+    for (int i = 0; i < 1000; i++) {
+      Coveralls c = new Coveralls("GC testing " + i);
+    }
+    
+    // Java Getter trait implementation for tests.
+    class JavaGetters implements Getters {
+      @Override
+      public Boolean getBool(Boolean v, Boolean arg2) {
+        return v != arg2;
+      }
+      
+      @Override
+      public String getString(String v, Boolean arg2) throws CoverallException {
+        if (v.equals("too-many-holes")) {
+          throw new CoverallException.TooManyHoles("too many holes");
+        } else if (v.equals("unexpected-error")) {
+          throw new RuntimeException("unexpected error");
+        } else if (arg2) {
+          return v.toUpperCase();
+        } else {
+          return v;
+        }
+      }
+      
+      @Override
+      public String getOption(String v, Boolean arg2) throws ComplexException {
+        if (v.equals("os-error")) {
+          throw new ComplexException.OsException((short)100, (short)200);
+        } else if (v.equals("unknown-error")) {
+          throw new ComplexException.UnknownException();
+        } else if (arg2) {
+          if (!v.isEmpty()) {
+            return v.toUpperCase();
+          } else {
+            return null;
+          }
+        } else {
+          return v;
+        }
+      }
+      
+      @Override
+      public List<Integer> getList(List<Integer> v, Boolean arg2) {
+        if (arg2) {
+          return v;
+        } else {
+          return List.of();
+        }
+      }
+      
+      @Override
+      public void getNothing(String v) {}
+      
+      @Override
+      public Coveralls roundTripObject(Coveralls coveralls) {
+        return coveralls;
+      }
+    }
+          
+    // Test traits implemented in Rust.
+    {
+      var rustGetters = Coverall.makeRustGetters();
+      Coverall.testGetters(rustGetters);
+      testGettersFromJava(rustGetters);
+    }
+
+    // Test traits implemented in Java.
+    {
+      var javaGetters = new JavaGetters();
+      Coverall.testGetters(javaGetters);
+      testGettersFromJava(javaGetters);
+    }
+
+    class JavaNode implements NodeTrait {
+      NodeTrait currentParent;
+      
+      @Override
+      public String name() {
+        return "node-kt";
+      }
+      
+      @Override
+      public void setParent(NodeTrait parent) {
+        this.currentParent = parent;
+      }
+
+      @Override
+      public NodeTrait getParent() {
+        return currentParent;
+      }
+
+      @Override
+      public Long strongCount() {
+        return 0L;
+      }
+    }
+
+    // Test NodeTrait
+    {
+      List<NodeTraitImpl> traits = (List<NodeTraitImpl>)(List<?>)Coverall.getTraits();
+      assert traits.get(0).name().equals("node-1");
+      // Note: strong counts are 1 more than you might expect, because the strongCount() method
+      // holds a strong ref.
+      assert traits.get(0).strongCount() == 2L;
+
+      assert traits.get(1).name().equals("node-2");
+      assert traits.get(1).strongCount() == 2L;
+
+      // Note: this doesn't increase the Rust strong count, since we wrap the Rust impl with a
+      // Swift impl before passing it to `setParent()`
+      traits.get(0).setParent(traits.get(1));
+      assert Coverall.ancestorNames(traits.get(0)).equals(Arrays.asList("node-2"));
+      assert Coverall.ancestorNames(traits.get(1)).isEmpty();
+      assert traits.get(1).strongCount() == 2L;
+      assert traits.get(0).getParent().name().equals("node-2");
+
+      JavaNode javaNode = new JavaNode();
+      traits.get(1).setParent(javaNode);
+      assert Coverall.ancestorNames(traits.get(0)).equals(Arrays.asList("node-2", "node-kt"));
+      assert Coverall.ancestorNames(traits.get(1)).equals(Arrays.asList("node-kt"));
+      assert Coverall.ancestorNames(javaNode).isEmpty();
+
+      traits.get(1).setParent(null);
+      javaNode.setParent(traits.get(0));
+      assert Coverall.ancestorNames(javaNode).equals(Arrays.asList("node-1", "node-2"));
+      assert Coverall.ancestorNames(traits.get(0)).equals(Arrays.asList("node-2"));
+      assert Coverall.ancestorNames(traits.get(1)).isEmpty();
+
+      // Unset everything and check that we don't get a memory error
+      javaNode.setParent(null);
+      traits.get(0).setParent(null);
+      for (NodeTraitImpl node : traits) {
+        node.close();
+      }
+    }
+
+    {
+      var rustGetters = Coverall.makeRustGetters();
+      // Check that these don't cause use-after-free bugs
+      Coverall.testRoundTripThroughRust(rustGetters);
+      Coverall.testRoundTripThroughForeign(new JavaGetters());
+    }
+
+    // Test StringUtil
+    {
+      var traits = Coverall.getStringUtilTraits();
+      assert traits.get(0).concat("cow", "boy").equals("cowboy");
+      assert traits.get(1).concat("cow", "boy").equals("cowboy");
+    }
+
+    // This tests that the UniFFI-generated scaffolding doesn't introduce any unexpected locking.
+    // We have one thread busy-wait for a some period of time, while a second thread repeatedly
+    // increments the counter and then checks if the object is still busy. The second thread should
+    // not be blocked on the first, and should reliably observe the first thread being busy.
+    // If it does not, that suggests UniFFI is accidentally serializing the two threads on access
+    // to the shared counter object.
+    try (ThreadsafeCounter counter = new ThreadsafeCounter()) {
+      ExecutorService executor = Executors.newFixedThreadPool(3);
+      try {
+        var busyWaiting = executor.submit(() -> {
+          // 300 ms should be long enough for the other thread to easily finish
+          // its loop, but not so long as to annoy the user with a slow test.
+          counter.busyWait(300);
+        });
+        Future<Integer> incrementing = executor.submit(() -> {
+          Integer count = 0;
+          for (int n = 0; n < 100; n++) {
+            // We expect most iterations of this loop to run concurrently with the busy-waiting thread.
+            count = counter.incrementIfBusy();
+          }
+          return count;
+        });
+
+        busyWaiting.get();
+        Integer count = incrementing.get();
+        assert count > 0 : MessageFormat.format("Counter doing the locking: incrementIfBusy={0}", count);
+      } finally {
+        executor.shutdown();
+      }
+    }
+
+    // This does not call Rust code.
+    // no defaults in Java, this code doesn't pass
+    // DictWithDefaults d = new DictWithDefaults();
+    // assert d.name().equals("default-value");
+    // assert d.category() == null;
+    // assert d.integer() == 31L;
+
+    DictWithDefaults d = new DictWithDefaults("this", "that", 42L);
+    assert d.name().equals("this");
+    assert d.category().equals("that");
+    assert d.integer() == 42L;
+
+    // Test bytes
+    try (Coveralls coveralls = new Coveralls("test_bytes")) {
+      assert new String(coveralls.reverse("123".getBytes(StandardCharsets.UTF_8)), StandardCharsets.UTF_8).equals("321");
+    }
+
+    // Test fakes using open classes
+    class FakePatch extends Patch {
+      private Color color;
+  
+      public FakePatch(Color color) {
+        super(NoPointer.INSTANCE);
+        this.color = color;
+      }
+
+      @Override
+      public Color color() {
+        return this.color;
+      }
+    } 
+
+    class FakeCoveralls extends Coveralls {
+      private String name;
+      private List<Repair> repairs = ArrayList.of();
+
+      public FakeCoveralls(String name) {
+        super(NoPointer.INSTANCE);
+        this.name = name;
+      }
+
+      @Override
+      public void addPatch(Patch patch) {
+        repairs += Repair(Instant.now(), patch);
+      }
+
+      @Override
+      public List<Repair> repairs() {
+        return repairs;
+      }
     }
   }
 }

--- a/tests/scripts/TestFixtureCoverall.java
+++ b/tests/scripts/TestFixtureCoverall.java
@@ -1,0 +1,18 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import uniffi.coverall.*;
+
+import java.time.Instant;
+import java.util.concurrent.*;
+
+public class TestFixtureCoverall {
+  public static void main(String[] args) throws Exception {
+    // Test some_dict()
+    {
+      var d = Coverall.createSomeDict();
+      assert d.text().equals("text");
+    }
+  }
+}

--- a/tests/scripts/TestRondpoint.java
+++ b/tests/scripts/TestRondpoint.java
@@ -74,7 +74,7 @@ public class TestRondpoint {
     affirmAllerRetour(List.of(-1, 0, 1).stream().map(i -> new DictionnaireNombresSignes(i.byteValue(), i.shortValue(), i, i.longValue())).collect(Collectors.toList()), rt::identiqueNombresSignes);
     affirmAllerRetour(List.of(0, 1).stream().map(i -> new DictionnaireNombres(i.byteValue(), i.shortValue(), i, i.longValue())).collect(Collectors.toList()), rt::identiqueNombres);
 
-    rt.destroy();
+    rt.close();
 
     // Test one way across the FFI.
     //
@@ -128,7 +128,7 @@ public class TestRondpoint {
     // MIN_VALUE is 4.9E-324. Accuracy and formatting get weird at small sizes.
     affirmEnchaine(List.of(0.0, 1.0, -1.0, Double.MIN_VALUE, Double.MAX_VALUE), st::toStringDouble, (s, n) -> Double.parseDouble(s) == n);
 
-    st.destroy();
+    st.close();
 
     // Defaults aren't supported in Java, so we check that our Java `None` equivalent goes across the barrier correctly
     // as an option and comes back instead. See Kotlin's rondpoint tests for reference default behavior if you want to
@@ -181,7 +181,7 @@ public class TestRondpoint {
     // Enums
     affirmAllerRetour(List.of(Enumeration.values()), op::sinonEnum);
 
-    op.destroy();
+    op.close();
 }
 
   private static <T> void affirmAllerRetour(List<T> vs, Function<T, T> f) {


### PR DESCRIPTION
Switched from `Disposable` to `AutoClosable`. Big difference is that `AutoClosable` `throws Exception` which makes it slightly more annoying in some use cases. It allows us to use `try-with-resources` though to make sure things that need to get destroyed do get destroyed. We can't inline functions like Kotlin is doing with `destroy` for `Disposable`, so we have to hold a strong reference to be able to `destroy` something after a block of code, which negates a bit of the point.

Disposable could be added back in the future (or in addition to AutoClosable) if necessary, but looking through the Rust code I didn't see anywhere a `destroy` was being presented from that side or anything.

Writing the coverall tests did catch a few edge cases that were fixed in this PR.