### PR TITLE
Crates releasable

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,9 @@
+name: Rust Release
+
+on:
+  workflow_dispatch: null
+
+jobs:
+  rust-release:
+    uses: IronCoreLabs/workflows/.github/workflows/rust-release.yaml@rust-release-v1
+    secrets: inherit

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,24 @@
 [package]
 name = "uniffi-bindgen-java"
 version = "0.1.0"
+authors = ["IronCore Labs <info@ironcorelabs.com>"]
+readme = "README.md"
+license = "mpl-2.0"
+repository = "https://github.com/IronCoreLabs/uniffi-bindgen-java"
+documentation = "https://docs.rs/uniffi-bindgen-java"
+keywords = [
+  "bindgen",
+  "ffi",
+  "java"
+]
+description = "a java bindings generator for uniffi rust"
+exclude = [
+  ".github/*",
+  ".envrc",
+  "flake.nix",
+  "flake.lock",
+  "RELEASING.md"
+]
 edition = "2021"
 
 [lib]


### PR DESCRIPTION
We have a binary dependency on this in `ironcore-alloy` so we need it on crates.io to be able to publish that crate.

It may be that ideally we split the two bindgens for `ironcore-alloy` into a separate `Cargo.toml` instead, but others may need this published anyway.