### PR TITLE
Fix leaking trait futures nondeterministically

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1260,26 +1260,13 @@ version = "0.29.1"
 source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1#82b8c7b557588500b6858291fd9ec8002cdacb36"
 dependencies = [
  "anyhow",
- "cargo_metadata",
- "uniffi_bindgen 0.29.1 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1)",
- "uniffi_build 0.29.1 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1)",
- "uniffi_core 0.29.1 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1)",
- "uniffi_macros 0.29.1 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1)",
-]
-
-[[package]]
-name = "uniffi"
-version = "0.29.1"
-source = "git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test#ed171f298b4251f7a463088b5a4fb375f38f28d2"
-dependencies = [
- "anyhow",
  "camino",
  "cargo_metadata",
  "clap",
- "uniffi_bindgen 0.29.1 (git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test)",
- "uniffi_build 0.29.1 (git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test)",
- "uniffi_core 0.29.1 (git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test)",
- "uniffi_macros 0.29.1 (git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test)",
+ "uniffi_bindgen 0.29.1 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1)",
+ "uniffi_build",
+ "uniffi_core",
+ "uniffi_macros",
 ]
 
 [[package]]
@@ -1309,8 +1296,8 @@ dependencies = [
  "uniffi-fixture-ext-types",
  "uniffi-fixture-futures",
  "uniffi-fixture-time",
- "uniffi_bindgen 0.29.1 (git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test)",
- "uniffi_meta 0.29.1 (git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test)",
+ "uniffi_bindgen 0.29.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi_meta 0.29.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "uniffi_testing",
 ]
 
@@ -1320,7 +1307,7 @@ version = "0.22.0"
 source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1#82b8c7b557588500b6858291fd9ec8002cdacb36"
 dependencies = [
  "thiserror",
- "uniffi 0.29.1 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1)",
+ "uniffi",
 ]
 
 [[package]]
@@ -1330,7 +1317,7 @@ source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1#82b8c7b557588
 dependencies = [
  "anyhow",
  "bytes",
- "uniffi 0.29.1 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1)",
+ "uniffi",
  "url",
 ]
 
@@ -1341,7 +1328,7 @@ source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1#82b8c7b557588
 dependencies = [
  "async-std",
  "thiserror",
- "uniffi 0.29.1 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1)",
+ "uniffi",
 ]
 
 [[package]]
@@ -1349,7 +1336,7 @@ name = "uniffi-example-geometry"
 version = "0.22.0"
 source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1#82b8c7b557588500b6858291fd9ec8002cdacb36"
 dependencies = [
- "uniffi 0.29.1 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1)",
+ "uniffi",
 ]
 
 [[package]]
@@ -1357,7 +1344,7 @@ name = "uniffi-example-rondpoint"
 version = "0.22.0"
 source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1#82b8c7b557588500b6858291fd9ec8002cdacb36"
 dependencies = [
- "uniffi 0.29.1 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1)",
+ "uniffi",
 ]
 
 [[package]]
@@ -1367,7 +1354,7 @@ source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1#82b8c7b557588
 dependencies = [
  "once_cell",
  "thiserror",
- "uniffi 0.29.1 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1)",
+ "uniffi",
 ]
 
 [[package]]
@@ -1377,7 +1364,7 @@ source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1#82b8c7b557588
 dependencies = [
  "anyhow",
  "bytes",
- "uniffi 0.29.1 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1)",
+ "uniffi",
  "uniffi-example-custom-types",
  "uniffi-fixture-ext-types-custom-types",
  "uniffi-fixture-ext-types-external-crate",
@@ -1394,7 +1381,7 @@ dependencies = [
  "anyhow",
  "bytes",
  "thiserror",
- "uniffi 0.29.1 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1)",
+ "uniffi",
 ]
 
 [[package]]
@@ -1410,7 +1397,7 @@ dependencies = [
  "anyhow",
  "bytes",
  "thiserror",
- "uniffi 0.29.1 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1)",
+ "uniffi",
 ]
 
 [[package]]
@@ -1419,21 +1406,21 @@ version = "0.22.0"
 source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1#82b8c7b557588500b6858291fd9ec8002cdacb36"
 dependencies = [
  "anyhow",
- "uniffi 0.29.1 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1)",
+ "uniffi",
  "uniffi-fixture-ext-types-lib-one",
 ]
 
 [[package]]
 name = "uniffi-fixture-futures"
 version = "0.21.0"
-source = "git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test#ed171f298b4251f7a463088b5a4fb375f38f28d2"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1#82b8c7b557588500b6858291fd9ec8002cdacb36"
 dependencies = [
  "async-trait",
  "futures",
  "once_cell",
  "thiserror",
  "tokio",
- "uniffi 0.29.1 (git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test)",
+ "uniffi",
 ]
 
 [[package]]
@@ -1443,7 +1430,30 @@ source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1#82b8c7b557588
 dependencies = [
  "chrono",
  "thiserror",
- "uniffi 0.29.1 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1)",
+ "uniffi",
+]
+
+[[package]]
+name = "uniffi_bindgen"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a792af1424cc8b3c43b44c1a6cb7935ed1fbe5584a74f70e8bab9799740266d"
+dependencies = [
+ "anyhow",
+ "camino",
+ "cargo_metadata",
+ "fs-err",
+ "glob",
+ "goblin",
+ "heck",
+ "once_cell",
+ "paste",
+ "rinja",
+ "serde",
+ "textwrap",
+ "toml",
+ "uniffi_meta 0.29.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi_udl 0.29.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1469,28 +1479,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "uniffi_bindgen"
-version = "0.29.1"
-source = "git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test#ed171f298b4251f7a463088b5a4fb375f38f28d2"
-dependencies = [
- "anyhow",
- "camino",
- "cargo_metadata",
- "fs-err",
- "glob",
- "goblin",
- "heck",
- "once_cell",
- "paste",
- "rinja",
- "serde",
- "textwrap",
- "toml",
- "uniffi_meta 0.29.1 (git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test)",
- "uniffi_udl 0.29.1 (git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test)",
-]
-
-[[package]]
 name = "uniffi_build"
 version = "0.29.1"
 source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1#82b8c7b557588500b6858291fd9ec8002cdacb36"
@@ -1501,30 +1489,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "uniffi_build"
-version = "0.29.1"
-source = "git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test#ed171f298b4251f7a463088b5a4fb375f38f28d2"
-dependencies = [
- "anyhow",
- "camino",
- "uniffi_bindgen 0.29.1 (git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test)",
-]
-
-[[package]]
 name = "uniffi_core"
 version = "0.29.1"
 source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1#82b8c7b557588500b6858291fd9ec8002cdacb36"
-dependencies = [
- "anyhow",
- "bytes",
- "once_cell",
- "static_assertions",
-]
-
-[[package]]
-name = "uniffi_core"
-version = "0.29.1"
-source = "git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test#ed171f298b4251f7a463088b5a4fb375f38f28d2"
 dependencies = [
  "anyhow",
  "async-compat",
@@ -1536,7 +1503,8 @@ dependencies = [
 [[package]]
 name = "uniffi_internal_macros"
 version = "0.29.1"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1#82b8c7b557588500b6858291fd9ec8002cdacb36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9902d4ed16c65e6c0222241024dd0bfeed07ea3deb7c470eb175e5f5ef406cd"
 dependencies = [
  "quote",
  "syn",
@@ -1545,7 +1513,7 @@ dependencies = [
 [[package]]
 name = "uniffi_internal_macros"
 version = "0.29.1"
-source = "git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test#ed171f298b4251f7a463088b5a4fb375f38f28d2"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1#82b8c7b557588500b6858291fd9ec8002cdacb36"
 dependencies = [
  "quote",
  "syn",
@@ -1568,19 +1536,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "uniffi_macros"
+name = "uniffi_meta"
 version = "0.29.1"
-source = "git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test#ed171f298b4251f7a463088b5a4fb375f38f28d2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d6027b971c2aa86350dd180aee9819729c7b99bacd381534511ff29d2c09cea"
 dependencies = [
- "camino",
- "fs-err",
- "once_cell",
- "proc-macro2",
- "quote",
- "serde",
- "syn",
- "toml",
- "uniffi_meta 0.29.1 (git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test)",
+ "anyhow",
+ "siphasher",
+ "uniffi_internal_macros 0.29.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1591,16 +1554,6 @@ dependencies = [
  "anyhow",
  "siphasher",
  "uniffi_internal_macros 0.29.1 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1)",
-]
-
-[[package]]
-name = "uniffi_meta"
-version = "0.29.1"
-source = "git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test#ed171f298b4251f7a463088b5a4fb375f38f28d2"
-dependencies = [
- "anyhow",
- "siphasher",
- "uniffi_internal_macros 0.29.1 (git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test)",
 ]
 
 [[package]]
@@ -1618,23 +1571,24 @@ dependencies = [
 [[package]]
 name = "uniffi_udl"
 version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52300b7a4ab02dc159a038a13d5bfe27aefbad300d91b0b501b3dda094c1e0a2"
+dependencies = [
+ "anyhow",
+ "textwrap",
+ "uniffi_meta 0.29.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "weedle2 5.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "uniffi_udl"
+version = "0.29.1"
 source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1#82b8c7b557588500b6858291fd9ec8002cdacb36"
 dependencies = [
  "anyhow",
  "textwrap",
  "uniffi_meta 0.29.1 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1)",
  "weedle2 5.0.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1)",
-]
-
-[[package]]
-name = "uniffi_udl"
-version = "0.29.1"
-source = "git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test#ed171f298b4251f7a463088b5a4fb375f38f28d2"
-dependencies = [
- "anyhow",
- "textwrap",
- "uniffi_meta 0.29.1 (git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test)",
- "weedle2 5.0.0 (git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test)",
 ]
 
 [[package]]
@@ -1750,7 +1704,8 @@ dependencies = [
 [[package]]
 name = "weedle2"
 version = "5.0.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1#82b8c7b557588500b6858291fd9ec8002cdacb36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "998d2c24ec099a87daf9467808859f9d82b61f1d9c9701251aea037f514eae0e"
 dependencies = [
  "nom",
 ]
@@ -1758,7 +1713,7 @@ dependencies = [
 [[package]]
 name = "weedle2"
 version = "5.0.0"
-source = "git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test#ed171f298b4251f7a463088b5a4fb375f38f28d2"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1#82b8c7b557588500b6858291fd9ec8002cdacb36"
 dependencies = [
  "nom",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1388,7 +1388,7 @@ dependencies = [
 
 [[package]]
 name = "uniffi-bindgen-java"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "camino",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1270,7 +1270,7 @@ dependencies = [
 [[package]]
 name = "uniffi"
 version = "0.29.1"
-source = "git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test#d4e53a5590df6782697876d061c3882c39fb4089"
+source = "git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test#4f7b8119246b19127f02ddb49c82f08f346f44f7"
 dependencies = [
  "anyhow",
  "camino",
@@ -1426,7 +1426,7 @@ dependencies = [
 [[package]]
 name = "uniffi-fixture-futures"
 version = "0.21.0"
-source = "git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test#d4e53a5590df6782697876d061c3882c39fb4089"
+source = "git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test#4f7b8119246b19127f02ddb49c82f08f346f44f7"
 dependencies = [
  "async-trait",
  "futures",
@@ -1471,7 +1471,7 @@ dependencies = [
 [[package]]
 name = "uniffi_bindgen"
 version = "0.29.1"
-source = "git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test#d4e53a5590df6782697876d061c3882c39fb4089"
+source = "git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test#4f7b8119246b19127f02ddb49c82f08f346f44f7"
 dependencies = [
  "anyhow",
  "camino",
@@ -1503,7 +1503,7 @@ dependencies = [
 [[package]]
 name = "uniffi_build"
 version = "0.29.1"
-source = "git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test#d4e53a5590df6782697876d061c3882c39fb4089"
+source = "git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test#4f7b8119246b19127f02ddb49c82f08f346f44f7"
 dependencies = [
  "anyhow",
  "camino",
@@ -1524,7 +1524,7 @@ dependencies = [
 [[package]]
 name = "uniffi_core"
 version = "0.29.1"
-source = "git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test#d4e53a5590df6782697876d061c3882c39fb4089"
+source = "git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test#4f7b8119246b19127f02ddb49c82f08f346f44f7"
 dependencies = [
  "anyhow",
  "async-compat",
@@ -1545,7 +1545,7 @@ dependencies = [
 [[package]]
 name = "uniffi_internal_macros"
 version = "0.29.1"
-source = "git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test#d4e53a5590df6782697876d061c3882c39fb4089"
+source = "git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test#4f7b8119246b19127f02ddb49c82f08f346f44f7"
 dependencies = [
  "quote",
  "syn",
@@ -1570,7 +1570,7 @@ dependencies = [
 [[package]]
 name = "uniffi_macros"
 version = "0.29.1"
-source = "git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test#d4e53a5590df6782697876d061c3882c39fb4089"
+source = "git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test#4f7b8119246b19127f02ddb49c82f08f346f44f7"
 dependencies = [
  "camino",
  "fs-err",
@@ -1596,7 +1596,7 @@ dependencies = [
 [[package]]
 name = "uniffi_meta"
 version = "0.29.1"
-source = "git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test#d4e53a5590df6782697876d061c3882c39fb4089"
+source = "git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test#4f7b8119246b19127f02ddb49c82f08f346f44f7"
 dependencies = [
  "anyhow",
  "siphasher",
@@ -1629,7 +1629,7 @@ dependencies = [
 [[package]]
 name = "uniffi_udl"
 version = "0.29.1"
-source = "git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test#d4e53a5590df6782697876d061c3882c39fb4089"
+source = "git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test#4f7b8119246b19127f02ddb49c82f08f346f44f7"
 dependencies = [
  "anyhow",
  "textwrap",
@@ -1758,7 +1758,7 @@ dependencies = [
 [[package]]
 name = "weedle2"
 version = "5.0.0"
-source = "git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test#d4e53a5590df6782697876d061c3882c39fb4089"
+source = "git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test#4f7b8119246b19127f02ddb49c82f08f346f44f7"
 dependencies = [
  "nom",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1260,13 +1260,26 @@ version = "0.29.1"
 source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1#82b8c7b557588500b6858291fd9ec8002cdacb36"
 dependencies = [
  "anyhow",
+ "cargo_metadata",
+ "uniffi_bindgen 0.29.1 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1)",
+ "uniffi_build 0.29.1 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1)",
+ "uniffi_core 0.29.1 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1)",
+ "uniffi_macros 0.29.1 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1)",
+]
+
+[[package]]
+name = "uniffi"
+version = "0.29.1"
+source = "git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test#4f7b8119246b19127f02ddb49c82f08f346f44f7"
+dependencies = [
+ "anyhow",
  "camino",
  "cargo_metadata",
  "clap",
- "uniffi_bindgen 0.29.1 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1)",
- "uniffi_build",
- "uniffi_core",
- "uniffi_macros",
+ "uniffi_bindgen 0.29.1 (git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test)",
+ "uniffi_build 0.29.1 (git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test)",
+ "uniffi_core 0.29.1 (git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test)",
+ "uniffi_macros 0.29.1 (git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test)",
 ]
 
 [[package]]
@@ -1296,8 +1309,8 @@ dependencies = [
  "uniffi-fixture-ext-types",
  "uniffi-fixture-futures",
  "uniffi-fixture-time",
- "uniffi_bindgen 0.29.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "uniffi_meta 0.29.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi_bindgen 0.29.1 (git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test)",
+ "uniffi_meta 0.29.1 (git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test)",
  "uniffi_testing",
 ]
 
@@ -1307,7 +1320,7 @@ version = "0.22.0"
 source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1#82b8c7b557588500b6858291fd9ec8002cdacb36"
 dependencies = [
  "thiserror",
- "uniffi",
+ "uniffi 0.29.1 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1)",
 ]
 
 [[package]]
@@ -1317,7 +1330,7 @@ source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1#82b8c7b557588
 dependencies = [
  "anyhow",
  "bytes",
- "uniffi",
+ "uniffi 0.29.1 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1)",
  "url",
 ]
 
@@ -1328,7 +1341,7 @@ source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1#82b8c7b557588
 dependencies = [
  "async-std",
  "thiserror",
- "uniffi",
+ "uniffi 0.29.1 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1)",
 ]
 
 [[package]]
@@ -1336,7 +1349,7 @@ name = "uniffi-example-geometry"
 version = "0.22.0"
 source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1#82b8c7b557588500b6858291fd9ec8002cdacb36"
 dependencies = [
- "uniffi",
+ "uniffi 0.29.1 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1)",
 ]
 
 [[package]]
@@ -1344,7 +1357,7 @@ name = "uniffi-example-rondpoint"
 version = "0.22.0"
 source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1#82b8c7b557588500b6858291fd9ec8002cdacb36"
 dependencies = [
- "uniffi",
+ "uniffi 0.29.1 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1)",
 ]
 
 [[package]]
@@ -1354,7 +1367,7 @@ source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1#82b8c7b557588
 dependencies = [
  "once_cell",
  "thiserror",
- "uniffi",
+ "uniffi 0.29.1 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1)",
 ]
 
 [[package]]
@@ -1364,7 +1377,7 @@ source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1#82b8c7b557588
 dependencies = [
  "anyhow",
  "bytes",
- "uniffi",
+ "uniffi 0.29.1 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1)",
  "uniffi-example-custom-types",
  "uniffi-fixture-ext-types-custom-types",
  "uniffi-fixture-ext-types-external-crate",
@@ -1381,7 +1394,7 @@ dependencies = [
  "anyhow",
  "bytes",
  "thiserror",
- "uniffi",
+ "uniffi 0.29.1 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1)",
 ]
 
 [[package]]
@@ -1397,7 +1410,7 @@ dependencies = [
  "anyhow",
  "bytes",
  "thiserror",
- "uniffi",
+ "uniffi 0.29.1 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1)",
 ]
 
 [[package]]
@@ -1406,21 +1419,21 @@ version = "0.22.0"
 source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1#82b8c7b557588500b6858291fd9ec8002cdacb36"
 dependencies = [
  "anyhow",
- "uniffi",
+ "uniffi 0.29.1 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1)",
  "uniffi-fixture-ext-types-lib-one",
 ]
 
 [[package]]
 name = "uniffi-fixture-futures"
 version = "0.21.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1#82b8c7b557588500b6858291fd9ec8002cdacb36"
+source = "git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test#4f7b8119246b19127f02ddb49c82f08f346f44f7"
 dependencies = [
  "async-trait",
  "futures",
  "once_cell",
  "thiserror",
  "tokio",
- "uniffi",
+ "uniffi 0.29.1 (git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test)",
 ]
 
 [[package]]
@@ -1430,30 +1443,7 @@ source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1#82b8c7b557588
 dependencies = [
  "chrono",
  "thiserror",
- "uniffi",
-]
-
-[[package]]
-name = "uniffi_bindgen"
-version = "0.29.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a792af1424cc8b3c43b44c1a6cb7935ed1fbe5584a74f70e8bab9799740266d"
-dependencies = [
- "anyhow",
- "camino",
- "cargo_metadata",
- "fs-err",
- "glob",
- "goblin",
- "heck",
- "once_cell",
- "paste",
- "rinja",
- "serde",
- "textwrap",
- "toml",
- "uniffi_meta 0.29.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "uniffi_udl 0.29.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi 0.29.1 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1)",
 ]
 
 [[package]]
@@ -1479,6 +1469,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "uniffi_bindgen"
+version = "0.29.1"
+source = "git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test#4f7b8119246b19127f02ddb49c82f08f346f44f7"
+dependencies = [
+ "anyhow",
+ "camino",
+ "cargo_metadata",
+ "fs-err",
+ "glob",
+ "goblin",
+ "heck",
+ "once_cell",
+ "paste",
+ "rinja",
+ "serde",
+ "textwrap",
+ "toml",
+ "uniffi_meta 0.29.1 (git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test)",
+ "uniffi_udl 0.29.1 (git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test)",
+]
+
+[[package]]
 name = "uniffi_build"
 version = "0.29.1"
 source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1#82b8c7b557588500b6858291fd9ec8002cdacb36"
@@ -1489,9 +1501,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "uniffi_build"
+version = "0.29.1"
+source = "git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test#4f7b8119246b19127f02ddb49c82f08f346f44f7"
+dependencies = [
+ "anyhow",
+ "camino",
+ "uniffi_bindgen 0.29.1 (git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test)",
+]
+
+[[package]]
 name = "uniffi_core"
 version = "0.29.1"
 source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1#82b8c7b557588500b6858291fd9ec8002cdacb36"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "once_cell",
+ "static_assertions",
+]
+
+[[package]]
+name = "uniffi_core"
+version = "0.29.1"
+source = "git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test#4f7b8119246b19127f02ddb49c82f08f346f44f7"
 dependencies = [
  "anyhow",
  "async-compat",
@@ -1503,8 +1536,7 @@ dependencies = [
 [[package]]
 name = "uniffi_internal_macros"
 version = "0.29.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9902d4ed16c65e6c0222241024dd0bfeed07ea3deb7c470eb175e5f5ef406cd"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1#82b8c7b557588500b6858291fd9ec8002cdacb36"
 dependencies = [
  "quote",
  "syn",
@@ -1513,7 +1545,7 @@ dependencies = [
 [[package]]
 name = "uniffi_internal_macros"
 version = "0.29.1"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1#82b8c7b557588500b6858291fd9ec8002cdacb36"
+source = "git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test#4f7b8119246b19127f02ddb49c82f08f346f44f7"
 dependencies = [
  "quote",
  "syn",
@@ -1536,14 +1568,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "uniffi_meta"
+name = "uniffi_macros"
 version = "0.29.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d6027b971c2aa86350dd180aee9819729c7b99bacd381534511ff29d2c09cea"
+source = "git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test#4f7b8119246b19127f02ddb49c82f08f346f44f7"
 dependencies = [
- "anyhow",
- "siphasher",
- "uniffi_internal_macros 0.29.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "camino",
+ "fs-err",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn",
+ "toml",
+ "uniffi_meta 0.29.1 (git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test)",
 ]
 
 [[package]]
@@ -1554,6 +1591,16 @@ dependencies = [
  "anyhow",
  "siphasher",
  "uniffi_internal_macros 0.29.1 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1)",
+]
+
+[[package]]
+name = "uniffi_meta"
+version = "0.29.1"
+source = "git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test#4f7b8119246b19127f02ddb49c82f08f346f44f7"
+dependencies = [
+ "anyhow",
+ "siphasher",
+ "uniffi_internal_macros 0.29.1 (git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test)",
 ]
 
 [[package]]
@@ -1571,24 +1618,23 @@ dependencies = [
 [[package]]
 name = "uniffi_udl"
 version = "0.29.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52300b7a4ab02dc159a038a13d5bfe27aefbad300d91b0b501b3dda094c1e0a2"
-dependencies = [
- "anyhow",
- "textwrap",
- "uniffi_meta 0.29.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "weedle2 5.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "uniffi_udl"
-version = "0.29.1"
 source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1#82b8c7b557588500b6858291fd9ec8002cdacb36"
 dependencies = [
  "anyhow",
  "textwrap",
  "uniffi_meta 0.29.1 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1)",
  "weedle2 5.0.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1)",
+]
+
+[[package]]
+name = "uniffi_udl"
+version = "0.29.1"
+source = "git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test#4f7b8119246b19127f02ddb49c82f08f346f44f7"
+dependencies = [
+ "anyhow",
+ "textwrap",
+ "uniffi_meta 0.29.1 (git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test)",
+ "weedle2 5.0.0 (git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test)",
 ]
 
 [[package]]
@@ -1704,8 +1750,7 @@ dependencies = [
 [[package]]
 name = "weedle2"
 version = "5.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "998d2c24ec099a87daf9467808859f9d82b61f1d9c9701251aea037f514eae0e"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1#82b8c7b557588500b6858291fd9ec8002cdacb36"
 dependencies = [
  "nom",
 ]
@@ -1713,7 +1758,7 @@ dependencies = [
 [[package]]
 name = "weedle2"
 version = "5.0.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1#82b8c7b557588500b6858291fd9ec8002cdacb36"
+source = "git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test#4f7b8119246b19127f02ddb49c82f08f346f44f7"
 dependencies = [
  "nom",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1270,7 +1270,7 @@ dependencies = [
 [[package]]
 name = "uniffi"
 version = "0.29.1"
-source = "git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test#4f7b8119246b19127f02ddb49c82f08f346f44f7"
+source = "git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test#1487059daabe8f5434cddfd6b9dce48174651bf7"
 dependencies = [
  "anyhow",
  "camino",
@@ -1426,7 +1426,7 @@ dependencies = [
 [[package]]
 name = "uniffi-fixture-futures"
 version = "0.21.0"
-source = "git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test#4f7b8119246b19127f02ddb49c82f08f346f44f7"
+source = "git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test#1487059daabe8f5434cddfd6b9dce48174651bf7"
 dependencies = [
  "async-trait",
  "futures",
@@ -1471,7 +1471,7 @@ dependencies = [
 [[package]]
 name = "uniffi_bindgen"
 version = "0.29.1"
-source = "git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test#4f7b8119246b19127f02ddb49c82f08f346f44f7"
+source = "git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test#1487059daabe8f5434cddfd6b9dce48174651bf7"
 dependencies = [
  "anyhow",
  "camino",
@@ -1503,7 +1503,7 @@ dependencies = [
 [[package]]
 name = "uniffi_build"
 version = "0.29.1"
-source = "git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test#4f7b8119246b19127f02ddb49c82f08f346f44f7"
+source = "git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test#1487059daabe8f5434cddfd6b9dce48174651bf7"
 dependencies = [
  "anyhow",
  "camino",
@@ -1524,7 +1524,7 @@ dependencies = [
 [[package]]
 name = "uniffi_core"
 version = "0.29.1"
-source = "git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test#4f7b8119246b19127f02ddb49c82f08f346f44f7"
+source = "git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test#1487059daabe8f5434cddfd6b9dce48174651bf7"
 dependencies = [
  "anyhow",
  "async-compat",
@@ -1545,7 +1545,7 @@ dependencies = [
 [[package]]
 name = "uniffi_internal_macros"
 version = "0.29.1"
-source = "git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test#4f7b8119246b19127f02ddb49c82f08f346f44f7"
+source = "git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test#1487059daabe8f5434cddfd6b9dce48174651bf7"
 dependencies = [
  "quote",
  "syn",
@@ -1570,7 +1570,7 @@ dependencies = [
 [[package]]
 name = "uniffi_macros"
 version = "0.29.1"
-source = "git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test#4f7b8119246b19127f02ddb49c82f08f346f44f7"
+source = "git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test#1487059daabe8f5434cddfd6b9dce48174651bf7"
 dependencies = [
  "camino",
  "fs-err",
@@ -1596,7 +1596,7 @@ dependencies = [
 [[package]]
 name = "uniffi_meta"
 version = "0.29.1"
-source = "git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test#4f7b8119246b19127f02ddb49c82f08f346f44f7"
+source = "git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test#1487059daabe8f5434cddfd6b9dce48174651bf7"
 dependencies = [
  "anyhow",
  "siphasher",
@@ -1629,7 +1629,7 @@ dependencies = [
 [[package]]
 name = "uniffi_udl"
 version = "0.29.1"
-source = "git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test#4f7b8119246b19127f02ddb49c82f08f346f44f7"
+source = "git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test#1487059daabe8f5434cddfd6b9dce48174651bf7"
 dependencies = [
  "anyhow",
  "textwrap",
@@ -1758,7 +1758,7 @@ dependencies = [
 [[package]]
 name = "weedle2"
 version = "5.0.0"
-source = "git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test#4f7b8119246b19127f02ddb49c82f08f346f44f7"
+source = "git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test#1487059daabe8f5434cddfd6b9dce48174651bf7"
 dependencies = [
  "nom",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,18 +4,18 @@ version = 4
 
 [[package]]
 name = "addr2line"
-version = "0.22.0"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e4503c46a5c0c7844e948c9a4d6acd9f50cccb4de1c48eb9e291ea17470c678"
+checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
 dependencies = [
  "gimli",
 ]
 
 [[package]]
-name = "adler"
-version = "1.0.2"
+name = "adler2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
 name = "aho-corasick"
@@ -28,15 +28,15 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.7"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "038dfcf04a5feb68e9c60b21c9625a54c2c0616e79b72b0fd87075a056ae1d1b"
+checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
 
 [[package]]
 name = "anyhow"
-version = "1.0.86"
+version = "1.0.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
+checksum = "dcfed56ad506cb2c684a14971b8861fdc3baaaae314b9e5f9bb532cbe3ba7a4f"
 
 [[package]]
 name = "async-channel"
@@ -76,14 +76,14 @@ dependencies = [
 
 [[package]]
 name = "async-executor"
-version = "1.12.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8828ec6e544c02b0d6691d21ed9f9218d0384a82542855073c2a3f58304aaf0"
+checksum = "30ca9a001c1e8ba5149f91a74362376cc6bc5b919d92d988668657bd570bdcec"
 dependencies = [
  "async-task",
  "concurrent-queue",
- "fastrand 2.1.0",
- "futures-lite 2.3.0",
+ "fastrand",
+ "futures-lite",
  "slab",
 ]
 
@@ -95,59 +95,30 @@ checksum = "05b1b633a2115cd122d73b955eadd9916c18c8f510ec9cd1686404c60ad1c29c"
 dependencies = [
  "async-channel 2.3.1",
  "async-executor",
- "async-io 2.3.3",
- "async-lock 3.4.0",
+ "async-io",
+ "async-lock",
  "blocking",
- "futures-lite 2.3.0",
+ "futures-lite",
  "once_cell",
 ]
 
 [[package]]
 name = "async-io"
-version = "1.13.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fc5b45d93ef0529756f812ca52e44c221b35341892d3dcc34132ac02f3dd2af"
+checksum = "43a2b323ccce0a1d90b449fd71f2a06ca7faa7c54c2751f06c9bd851fc061059"
 dependencies = [
- "async-lock 2.8.0",
- "autocfg",
- "cfg-if",
- "concurrent-queue",
- "futures-lite 1.13.0",
- "log",
- "parking",
- "polling 2.8.0",
- "rustix 0.37.27",
- "slab",
- "socket2",
- "waker-fn",
-]
-
-[[package]]
-name = "async-io"
-version = "2.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d6baa8f0178795da0e71bc42c9e5d13261aac7ee549853162e66a241ba17964"
-dependencies = [
- "async-lock 3.4.0",
+ "async-lock",
  "cfg-if",
  "concurrent-queue",
  "futures-io",
- "futures-lite 2.3.0",
+ "futures-lite",
  "parking",
- "polling 3.7.1",
- "rustix 0.38.34",
+ "polling",
+ "rustix",
  "slab",
  "tracing",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "async-lock"
-version = "2.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "287272293e9d8c41773cec55e365490fe034813a2f172f502d6ddcf75b2f582b"
-dependencies = [
- "event-listener 2.5.3",
+ "windows-sys",
 ]
 
 [[package]]
@@ -156,26 +127,26 @@ version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff6e472cdea888a4bd64f342f09b3f50e1886d32afe8df3d663c01140b811b18"
 dependencies = [
- "event-listener 5.3.1",
+ "event-listener 5.4.0",
  "event-listener-strategy",
  "pin-project-lite",
 ]
 
 [[package]]
 name = "async-std"
-version = "1.12.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62565bb4402e926b29953c785397c6dc0391b7b446e45008b0049eb43cec6f5d"
+checksum = "730294c1c08c2e0f85759590518f6333f0d5a0a766a27d519c1b244c3dfd8a24"
 dependencies = [
  "async-channel 1.9.0",
  "async-global-executor",
- "async-io 1.13.0",
- "async-lock 2.8.0",
+ "async-io",
+ "async-lock",
  "crossbeam-utils",
  "futures-channel",
  "futures-core",
  "futures-io",
- "futures-lite 1.13.0",
+ "futures-lite",
  "gloo-timers",
  "kv-log-macro",
  "log",
@@ -195,9 +166,9 @@ checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
-version = "0.1.80"
+version = "0.1.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6fa2087f2753a7da8cc1c0dbfcf89579dd57458e36769de5ac750b4671737ca"
+checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -212,45 +183,39 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
+checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "backtrace"
-version = "0.3.73"
+version = "0.3.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cc23269a4f8976d0a4d2e7109211a419fe30e8d88d677cd60b6bc79c5732e0a"
+checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
 dependencies = [
  "addr2line",
- "cc",
  "cfg-if",
  "libc",
  "miniz_oxide",
  "object",
  "rustc-demangle",
+ "windows-targets",
 ]
 
 [[package]]
 name = "basic-toml"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "823388e228f614e9558c6804262db37960ec8821856535f5c3f59913140558f8"
+checksum = "ba62675e8242a4c4e806d12f11d136e626e6c8361d6b829310732241652a178a"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "bitflags"
-version = "1.3.2"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "bitflags"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
+checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 
 [[package]]
 name = "blocking"
@@ -261,36 +226,36 @@ dependencies = [
  "async-channel 2.3.1",
  "async-task",
  "futures-io",
- "futures-lite 2.3.0",
+ "futures-lite",
  "piper",
 ]
 
 [[package]]
 name = "bumpalo"
-version = "3.16.0"
+version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
+checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
 
 [[package]]
 name = "bytes"
-version = "1.6.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
+checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "camino"
-version = "1.1.7"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0ec6b951b160caa93cc0c7b209e5a3bff7aae9062213451ac99493cd844c239"
+checksum = "8b96ec4966b5813e2c0507c1f86115c8c5abaadc3980879c3424042a02fd1ad3"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "cargo-platform"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24b1f0365a6c6bb4020cd05806fd0d33c44d38046b8bd7f0e40814b9763cabfc"
+checksum = "e35af189006b9c0f00a064685c727031e3ed2d8020f7ba284d78cc2671bd36ea"
 dependencies = [
  "serde",
 ]
@@ -310,12 +275,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cc"
-version = "1.0.99"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96c51067fd44124faa7f870b4b1c969379ad32b2ba805aa959430ceaa384f695"
-
-[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -323,18 +282,18 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.38"
+version = "0.4.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
+checksum = "1a7964611d71df112cb1730f2ee67324fcf4d0fc6606acbbe9bfe06df124637c"
 dependencies = [
  "num-traits",
 ]
 
 [[package]]
 name = "clap"
-version = "4.5.7"
+version = "4.5.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5db83dced34638ad474f39f250d7fea9598bdd239eaced1bdf45d597da0f433f"
+checksum = "d8aa86934b44c19c50f87cc2790e19f54f7a67aedb64101c2e1a2e5ecfb73944"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -342,9 +301,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.7"
+version = "4.5.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7e204572485eb3fbf28f871612191521df159bc3e15a9f5064c66dba3a8c05f"
+checksum = "2414dbb2dd0695280da6ea9261e327479e9d37b0630f6b53ba2a11c60c679fd9"
 dependencies = [
  "anstyle",
  "clap_lex",
@@ -353,9 +312,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.5"
+version = "4.5.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c780290ccf4fb26629baa7a1081e68ced113f1d3ec302fa5948f1c381ebf06c6"
+checksum = "09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -365,9 +324,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.1"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b82cf0babdbd58558212896d1a4272303a57bdb245c2bf1147185fb45640e70"
+checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "concurrent-queue"
@@ -380,15 +339,15 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.20"
+version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "displaydoc"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "487585f4d0c6655fe74905e2504d8ad6908e4db67f744eb140876906c2f3175d"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -397,18 +356,18 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.12.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dca9240753cf90908d7e4aac30f630662b02aebaa1b58a3cadabdb23385b58b"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "errno"
-version = "0.3.9"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
+checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -419,9 +378,9 @@ checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
 name = "event-listener"
-version = "5.3.1"
+version = "5.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6032be9bd27023a771701cc49f9f053c751055f71efb2e0ae5c15809093675ba"
+checksum = "3492acde4c3fc54c845eaab3eed8bd00c7a7d881f78bfc801e43a93dec1331ae"
 dependencies = [
  "concurrent-queue",
  "parking",
@@ -430,28 +389,19 @@ dependencies = [
 
 [[package]]
 name = "event-listener-strategy"
-version = "0.5.2"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f214dc438f977e6d4e3500aaa277f5ad94ca83fbbd9b1a15713ce2344ccc5a1"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
 dependencies = [
- "event-listener 5.3.1",
+ "event-listener 5.4.0",
  "pin-project-lite",
 ]
 
 [[package]]
 name = "fastrand"
-version = "1.9.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
-dependencies = [
- "instant",
-]
-
-[[package]]
-name = "fastrand"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "form_urlencoded"
@@ -473,9 +423,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -488,9 +438,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -498,15 +448,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -515,32 +465,17 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
 name = "futures-lite"
-version = "1.13.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49a9d51ce47660b1e808d3c990b4709f2f415d928835a17dfd16991515c46bce"
+checksum = "f5edaec856126859abb19ed65f39e90fea3a9574b9707f13539acf4abf7eb532"
 dependencies = [
- "fastrand 1.9.0",
- "futures-core",
- "futures-io",
- "memchr",
- "parking",
- "pin-project-lite",
- "waker-fn",
-]
-
-[[package]]
-name = "futures-lite"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52527eb5074e35e9339c6b4e8d12600c7128b68fb25dcb9fa9dec18f7c25f3a5"
-dependencies = [
- "fastrand 2.1.0",
+ "fastrand",
  "futures-core",
  "futures-io",
  "parking",
@@ -549,9 +484,9 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -560,21 +495,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
 
 [[package]]
 name = "futures-task"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
 
 [[package]]
 name = "futures-util"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -590,21 +525,21 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.29.0"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
+checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "glob"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "gloo-timers"
-version = "0.2.6"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b995a66bb87bebce9a0f4a95aed01daca4872c050bfcb21653361c03bc35e5c"
+checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -631,9 +566,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.9"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
+checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
 
 [[package]]
 name = "icu_collections"
@@ -676,9 +611,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locid_transform_data"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdc8ff3388f852bede6b579ad4e978ab004f139284d7b28715f773507b946f6e"
+checksum = "7515e6d781098bf9f7205ab3fc7e9709d34554ae0b21ddbcb5febfa4bc7df11d"
 
 [[package]]
 name = "icu_normalizer"
@@ -700,15 +635,15 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8cafbf7aa791e9b22bec55a167906f9e1215fd475cd22adfcf660e03e989516"
+checksum = "c5e8338228bdc8ab83303f16b797e177953730f601a96c25d10cb3ab0daa0cb7"
 
 [[package]]
 name = "icu_properties"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f8ac670d7422d7f76b32e17a5db556510825b29ec9154f235977c9caba61036"
+checksum = "93d6020766cfc6302c15dbbc9c8778c37e62c14427cb7f6e601d849e092aeef5"
 dependencies = [
  "displaydoc",
  "icu_collections",
@@ -721,9 +656,9 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67a8effbc3dd3e4ba1afa8ad918d5684b8868b3b26500753effea8d2eed19569"
+checksum = "85fb8799753b75aee8d2a21d7c14d9f38921b54b3dbda10f5a3c7a7b82dba5e2"
 
 [[package]]
 name = "icu_provider"
@@ -755,34 +690,23 @@ dependencies = [
 
 [[package]]
 name = "idna"
-version = "1.0.0"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4716a3a0933a1d01c2f72450e89596eb51dd34ef3c211ccd875acdf1f8fe47ed"
+checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
 dependencies = [
- "icu_normalizer",
- "icu_properties",
+ "idna_adapter",
  "smallvec",
  "utf8_iter",
 ]
 
 [[package]]
-name = "instant"
-version = "0.1.13"
+name = "idna_adapter"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
+checksum = "daca1df1c957320b2cf139ac61e7bd64fed304c5040df000a745aa1de3b4ef71"
 dependencies = [
- "cfg-if",
-]
-
-[[package]]
-name = "io-lifetimes"
-version = "1.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
-dependencies = [
- "hermit-abi",
- "libc",
- "windows-sys 0.48.0",
+ "icu_normalizer",
+ "icu_properties",
 ]
 
 [[package]]
@@ -796,16 +720,17 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.11"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "js-sys"
-version = "0.3.69"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
+ "once_cell",
  "wasm-bindgen",
 ]
 
@@ -820,42 +745,36 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.155"
+version = "0.2.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
+checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.3.8"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.4.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "litemap"
-version = "0.7.3"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "643cb0b8d4fcc284004d5fd0d67ccf61dfffadb7f75e1e71bc420f4688a3a704"
+checksum = "23fb14cb19457329c82206317a5663005a4d404783dc74f4252769b0d5f42856"
 
 [[package]]
 name = "log"
-version = "0.4.21"
+version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
+checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 dependencies = [
  "value-bag",
 ]
 
 [[package]]
 name = "memchr"
-version = "2.7.2"
+version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "mime"
@@ -865,9 +784,9 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "mime_guess"
-version = "2.0.4"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4192263c238a5f0d0c6bfd21f336a313a4ce1c450542449ca191bb657b4642ef"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
 dependencies = [
  "mime",
  "unicase",
@@ -881,11 +800,11 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.7.3"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87dfd01fe195c66b572b37921ad8803d010623c0aca821bea2302239d155cdae"
+checksum = "3be647b768db090acb35d5ec5db2b0e1f1de11133ca123b9eacf5137868f892a"
 dependencies = [
- "adler",
+ "adler2",
 ]
 
 [[package]]
@@ -909,24 +828,24 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.36.0"
+version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "576dfe1fc8f9df304abb159d767a29d0476f7750fbf8aa7ad07816004a207434"
+checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.19.0"
+version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "parking"
-version = "2.2.0"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb813b8af86854136c6922af0598d719255ecb2179515e6e7730d468f05c9cae"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "paste"
@@ -942,9 +861,9 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.14"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
 name = "pin-utils"
@@ -954,12 +873,12 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "piper"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae1d5c74c9876f070d3e8fd503d748c7d974c3e48da8f41350fa5222ef9b4391"
+checksum = "96c8c490f422ef9a4efd2cb5b42b76c8613d7e7dfc1caf667b8a3350a5acc066"
 dependencies = [
  "atomic-waker",
- "fastrand 2.1.0",
+ "fastrand",
  "futures-io",
 ]
 
@@ -971,58 +890,42 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "polling"
-version = "2.8.0"
+version = "3.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b2d323e8ca7996b3e23126511a523f7e62924d93ecd5ae73b333815b0eb3dce"
-dependencies = [
- "autocfg",
- "bitflags 1.3.2",
- "cfg-if",
- "concurrent-queue",
- "libc",
- "log",
- "pin-project-lite",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "polling"
-version = "3.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e6a007746f34ed64099e88783b0ae369eaa3da6392868ba262e2af9b8fbaea1"
+checksum = "a604568c3202727d1507653cb121dbd627a58684eb09a820fd746bee38b4442f"
 dependencies = [
  "cfg-if",
  "concurrent-queue",
  "hermit-abi",
  "pin-project-lite",
- "rustix 0.38.34",
+ "rustix",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.85"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22244ce15aa966053a896d1accb3a6e68469b97c7f33f284b99f0d576879fc23"
+checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.36"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "regex"
-version = "1.10.5"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b91213439dad192326a0d7c6ee3955910425f441d7038e0d6933b0aec5c4517f"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1032,9 +935,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.7"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1043,9 +946,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "rinja"
@@ -1100,36 +1003,28 @@ checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustix"
-version = "0.37.27"
+version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fea8ca367a3a01fe35e6943c400addf443c0f57670e6ec51196f71a4b8762dd2"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags",
  "errno",
- "io-lifetimes",
  "libc",
- "linux-raw-sys 0.3.8",
- "windows-sys 0.48.0",
+ "linux-raw-sys",
+ "windows-sys",
 ]
 
 [[package]]
-name = "rustix"
-version = "0.38.34"
+name = "rustversion"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
-dependencies = [
- "bitflags 2.5.0",
- "errno",
- "libc",
- "linux-raw-sys 0.4.14",
- "windows-sys 0.52.0",
-]
+checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
 
 [[package]]
 name = "ryu"
-version = "1.0.18"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "scroll"
@@ -1142,9 +1037,9 @@ dependencies = [
 
 [[package]]
 name = "scroll_derive"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f81c2fde025af7e69b1d1420531c8a8811ca898919db177141a85313b1cb932"
+checksum = "1783eabc414609e28a5ba76aee5ddd52199f7107a0b24c2e9746a1ecc34a683d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1153,27 +1048,27 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.23"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
+checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "serde"
-version = "1.0.203"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7253ab4de971e72fb7be983802300c30b5a7f0c2e56fab8abfc6a214307c0094"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.203"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1182,11 +1077,12 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.117"
+version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "455182ea6142b14f93f4bc5320a2b31c1f266b66a4a5c858b013302a5d8cbfc3"
+checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
  "itoa",
+ "memchr",
  "ryu",
  "serde",
 ]
@@ -1208,25 +1104,15 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.13.2"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
 
 [[package]]
 name = "smawk"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
-
-[[package]]
-name = "socket2"
-version = "0.4.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f7916fc008ca5542385b89a3d3ce689953c143e9304a9bf8beec1de48994c0d"
-dependencies = [
- "libc",
- "winapi",
-]
 
 [[package]]
 name = "stable_deref_trait"
@@ -1248,9 +1134,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.66"
+version = "2.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c42f3f41a2de00b01c0aaad383c5a45241efc8b2d1eda5661812fda5f3cdcff5"
+checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1270,9 +1156,9 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.16.1"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23d434d3f8967a09480fb04132ebe0a3e088c173e6d0ee7897abbdf4eab0f8b9"
+checksum = "c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057"
 dependencies = [
  "smawk",
  "unicode-linebreak",
@@ -1281,18 +1167,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.61"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c546c80d6be4bc6a00c0f01730c08df82eaa7a7a61f11d656526506112cc1709"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.61"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1311,9 +1197,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.38.0"
+version = "1.44.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba4f4a02a7a80d6f274636f0aa95c7e383b912d41fe721a31f29e29698585a4a"
+checksum = "e6b88822cbe49de4185e3a4cbf8321dd487cf5fe0c5c65695fef6346371e9c48"
 dependencies = [
  "backtrace",
  "pin-project-lite",
@@ -1330,9 +1216,9 @@ dependencies = [
 
 [[package]]
 name = "tracing"
-version = "0.1.40"
+version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
+checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
  "pin-project-lite",
  "tracing-core",
@@ -1340,24 +1226,21 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.32"
+version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
+checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
 
 [[package]]
 name = "unicase"
-version = "2.7.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7d2d4dafb69621809a81864c9c1b864479e1235c0dd4e199924b9742439ed89"
-dependencies = [
- "version_check",
-]
+checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.12"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
 name = "unicode-linebreak"
@@ -1367,9 +1250,9 @@ checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.13"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0336d538f7abc86d282a4189614dfaa90810dfc2c6f6427eaf88e16311dd225d"
+checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
 name = "uniffi"
@@ -1387,7 +1270,7 @@ dependencies = [
 [[package]]
 name = "uniffi"
 version = "0.29.1"
-source = "git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test#0abd28c353f2a7ef3f1f786d886f0232a72efb42"
+source = "git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test#d4e53a5590df6782697876d061c3882c39fb4089"
 dependencies = [
  "anyhow",
  "camino",
@@ -1543,7 +1426,7 @@ dependencies = [
 [[package]]
 name = "uniffi-fixture-futures"
 version = "0.21.0"
-source = "git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test#0abd28c353f2a7ef3f1f786d886f0232a72efb42"
+source = "git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test#d4e53a5590df6782697876d061c3882c39fb4089"
 dependencies = [
  "async-trait",
  "futures",
@@ -1588,7 +1471,7 @@ dependencies = [
 [[package]]
 name = "uniffi_bindgen"
 version = "0.29.1"
-source = "git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test#0abd28c353f2a7ef3f1f786d886f0232a72efb42"
+source = "git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test#d4e53a5590df6782697876d061c3882c39fb4089"
 dependencies = [
  "anyhow",
  "camino",
@@ -1620,7 +1503,7 @@ dependencies = [
 [[package]]
 name = "uniffi_build"
 version = "0.29.1"
-source = "git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test#0abd28c353f2a7ef3f1f786d886f0232a72efb42"
+source = "git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test#d4e53a5590df6782697876d061c3882c39fb4089"
 dependencies = [
  "anyhow",
  "camino",
@@ -1641,7 +1524,7 @@ dependencies = [
 [[package]]
 name = "uniffi_core"
 version = "0.29.1"
-source = "git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test#0abd28c353f2a7ef3f1f786d886f0232a72efb42"
+source = "git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test#d4e53a5590df6782697876d061c3882c39fb4089"
 dependencies = [
  "anyhow",
  "async-compat",
@@ -1662,7 +1545,7 @@ dependencies = [
 [[package]]
 name = "uniffi_internal_macros"
 version = "0.29.1"
-source = "git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test#0abd28c353f2a7ef3f1f786d886f0232a72efb42"
+source = "git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test#d4e53a5590df6782697876d061c3882c39fb4089"
 dependencies = [
  "quote",
  "syn",
@@ -1687,7 +1570,7 @@ dependencies = [
 [[package]]
 name = "uniffi_macros"
 version = "0.29.1"
-source = "git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test#0abd28c353f2a7ef3f1f786d886f0232a72efb42"
+source = "git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test#d4e53a5590df6782697876d061c3882c39fb4089"
 dependencies = [
  "camino",
  "fs-err",
@@ -1713,7 +1596,7 @@ dependencies = [
 [[package]]
 name = "uniffi_meta"
 version = "0.29.1"
-source = "git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test#0abd28c353f2a7ef3f1f786d886f0232a72efb42"
+source = "git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test#d4e53a5590df6782697876d061c3882c39fb4089"
 dependencies = [
  "anyhow",
  "siphasher",
@@ -1746,7 +1629,7 @@ dependencies = [
 [[package]]
 name = "uniffi_udl"
 version = "0.29.1"
-source = "git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test#0abd28c353f2a7ef3f1f786d886f0232a72efb42"
+source = "git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test#d4e53a5590df6782697876d061c3882c39fb4089"
 dependencies = [
  "anyhow",
  "textwrap",
@@ -1756,9 +1639,9 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "2.5.1"
+version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7c25da092f0a868cdf09e8674cd3b7ef3a7d92a24253e663a2fb85e2496de56"
+checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -1779,41 +1662,30 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "value-bag"
-version = "1.9.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a84c137d37ab0142f0f2ddfe332651fdbf252e7b7dbb4e67b6c1f1b2e925101"
-
-[[package]]
-name = "version_check"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
-
-[[package]]
-name = "waker-fn"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "317211a0dc0ceedd78fb2ca9a44aed3d7b9b26f81870d485c07122b4350673b7"
+checksum = "943ce29a8a743eb10d6082545d861b24f9d1b160b7d741e0f2cdf726bec909c5"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.92"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
 dependencies = [
  "cfg-if",
+ "once_cell",
+ "rustversion",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.92"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
 dependencies = [
  "bumpalo",
  "log",
- "once_cell",
  "proc-macro2",
  "quote",
  "syn",
@@ -1822,21 +1694,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.42"
+version = "0.4.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76bc14366121efc8dbb487ab05bcc9d346b3b5ec0eaa76e46594cabbe51762c0"
+checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
 dependencies = [
  "cfg-if",
  "js-sys",
+ "once_cell",
  "wasm-bindgen",
  "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.92"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1844,9 +1717,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.92"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1857,15 +1730,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.92"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "web-sys"
-version = "0.3.69"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef"
+checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -1882,171 +1758,83 @@ dependencies = [
 [[package]]
 name = "weedle2"
 version = "5.0.0"
-source = "git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test#0abd28c353f2a7ef3f1f786d886f0232a72efb42"
+source = "git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test#d4e53a5590df6782697876d061c3882c39fb4089"
 dependencies = [
  "nom",
 ]
 
 [[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
 name = "windows-sys"
-version = "0.48.0"
+version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets 0.52.5",
+ "windows-targets",
 ]
 
 [[package]]
 name = "windows-targets"
-version = "0.48.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.52.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f0713a46559409d202e70e28227288446bf7841d3211583a4b53e3f6d96e7eb"
-dependencies = [
- "windows_aarch64_gnullvm 0.52.5",
- "windows_aarch64_msvc 0.52.5",
- "windows_i686_gnu 0.52.5",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
  "windows_i686_gnullvm",
- "windows_i686_msvc 0.52.5",
- "windows_x86_64_gnu 0.52.5",
- "windows_x86_64_gnullvm 0.52.5",
- "windows_x86_64_msvc 0.52.5",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.52.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7088eed71e8b8dda258ecc8bac5fb1153c5cffaf2578fc8ff5d61e23578d3263"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.52.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9985fd1504e250c615ca5f281c3f7a6da76213ebd5ccc9561496568a2752afb6"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.48.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.52.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88ba073cf16d5372720ec942a8ccbf61626074c6d4dd2e745299726ce8b89670"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
 name = "windows_i686_gnullvm"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87f4261229030a858f36b459e748ae97545d6f1ec60e5e0d6a3d32e0dc232ee9"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.52.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db3c2bf3d13d5b658be73463284eaf12830ac9a26a90c717b7f771dfe97487bf"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.48.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.52.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e4246f76bdeff09eb48875a0fd3e2af6aada79d409d33011886d3e1581517d9"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.52.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "852298e482cd67c356ddd9570386e2862b5673c85bd5f88df9ab6802b334c596"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.48.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.52.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "write16"
@@ -2062,9 +1850,9 @@ checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
 
 [[package]]
 name = "yoke"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c5b1314b079b0930c31e3af543d8ee1757b1951ae1e1565ec704403a7240ca5"
+checksum = "120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -2074,9 +1862,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28cc31741b18cb6f1d5ff12f5b7523e3d6eb0852bbbad19d73905511d9849b95"
+checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2086,18 +1874,18 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.4"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91ec111ce797d0e0784a1116d0ddcdbea84322cd79e5d5ad173daeba4f93ab55"
+checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.4"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ea7b4a3637ea8669cedf0f1fd5c286a17f3de97b8dd5a70a6c167a1730e63a5"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2107,9 +1895,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.10.2"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb2cc8827d6c0994478a15c53f374f46fbd41bea663d809b14744bc42e6b109c"
+checksum = "aa2b893d79df23bfb12d5461018d408ea19dfafe76c2c7ef6d4eba614f8ff079"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -2118,9 +1906,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.10.2"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97cf56601ee5052b4417d90c8755c6683473c926039908196cf35d99f893ebe7"
+checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1260,26 +1260,13 @@ version = "0.29.1"
 source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1#82b8c7b557588500b6858291fd9ec8002cdacb36"
 dependencies = [
  "anyhow",
- "cargo_metadata",
- "uniffi_bindgen 0.29.1 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1)",
- "uniffi_build 0.29.1 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1)",
- "uniffi_core 0.29.1 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1)",
- "uniffi_macros 0.29.1 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1)",
-]
-
-[[package]]
-name = "uniffi"
-version = "0.29.1"
-source = "git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test#4f7b8119246b19127f02ddb49c82f08f346f44f7"
-dependencies = [
- "anyhow",
  "camino",
  "cargo_metadata",
  "clap",
- "uniffi_bindgen 0.29.1 (git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test)",
- "uniffi_build 0.29.1 (git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test)",
- "uniffi_core 0.29.1 (git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test)",
- "uniffi_macros 0.29.1 (git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test)",
+ "uniffi_bindgen 0.29.1 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1)",
+ "uniffi_build",
+ "uniffi_core",
+ "uniffi_macros",
 ]
 
 [[package]]
@@ -1309,8 +1296,8 @@ dependencies = [
  "uniffi-fixture-ext-types",
  "uniffi-fixture-futures",
  "uniffi-fixture-time",
- "uniffi_bindgen 0.29.1 (git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test)",
- "uniffi_meta 0.29.1 (git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test)",
+ "uniffi_bindgen 0.29.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi_meta 0.29.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "uniffi_testing",
 ]
 
@@ -1320,7 +1307,7 @@ version = "0.22.0"
 source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1#82b8c7b557588500b6858291fd9ec8002cdacb36"
 dependencies = [
  "thiserror",
- "uniffi 0.29.1 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1)",
+ "uniffi",
 ]
 
 [[package]]
@@ -1330,7 +1317,7 @@ source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1#82b8c7b557588
 dependencies = [
  "anyhow",
  "bytes",
- "uniffi 0.29.1 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1)",
+ "uniffi",
  "url",
 ]
 
@@ -1341,7 +1328,7 @@ source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1#82b8c7b557588
 dependencies = [
  "async-std",
  "thiserror",
- "uniffi 0.29.1 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1)",
+ "uniffi",
 ]
 
 [[package]]
@@ -1349,7 +1336,7 @@ name = "uniffi-example-geometry"
 version = "0.22.0"
 source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1#82b8c7b557588500b6858291fd9ec8002cdacb36"
 dependencies = [
- "uniffi 0.29.1 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1)",
+ "uniffi",
 ]
 
 [[package]]
@@ -1357,7 +1344,7 @@ name = "uniffi-example-rondpoint"
 version = "0.22.0"
 source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1#82b8c7b557588500b6858291fd9ec8002cdacb36"
 dependencies = [
- "uniffi 0.29.1 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1)",
+ "uniffi",
 ]
 
 [[package]]
@@ -1367,7 +1354,7 @@ source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1#82b8c7b557588
 dependencies = [
  "once_cell",
  "thiserror",
- "uniffi 0.29.1 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1)",
+ "uniffi",
 ]
 
 [[package]]
@@ -1377,7 +1364,7 @@ source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1#82b8c7b557588
 dependencies = [
  "anyhow",
  "bytes",
- "uniffi 0.29.1 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1)",
+ "uniffi",
  "uniffi-example-custom-types",
  "uniffi-fixture-ext-types-custom-types",
  "uniffi-fixture-ext-types-external-crate",
@@ -1394,7 +1381,7 @@ dependencies = [
  "anyhow",
  "bytes",
  "thiserror",
- "uniffi 0.29.1 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1)",
+ "uniffi",
 ]
 
 [[package]]
@@ -1410,7 +1397,7 @@ dependencies = [
  "anyhow",
  "bytes",
  "thiserror",
- "uniffi 0.29.1 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1)",
+ "uniffi",
 ]
 
 [[package]]
@@ -1419,21 +1406,21 @@ version = "0.22.0"
 source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1#82b8c7b557588500b6858291fd9ec8002cdacb36"
 dependencies = [
  "anyhow",
- "uniffi 0.29.1 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1)",
+ "uniffi",
  "uniffi-fixture-ext-types-lib-one",
 ]
 
 [[package]]
 name = "uniffi-fixture-futures"
 version = "0.21.0"
-source = "git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test#4f7b8119246b19127f02ddb49c82f08f346f44f7"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1#82b8c7b557588500b6858291fd9ec8002cdacb36"
 dependencies = [
  "async-trait",
  "futures",
  "once_cell",
  "thiserror",
  "tokio",
- "uniffi 0.29.1 (git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test)",
+ "uniffi",
 ]
 
 [[package]]
@@ -1443,7 +1430,30 @@ source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1#82b8c7b557588
 dependencies = [
  "chrono",
  "thiserror",
- "uniffi 0.29.1 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1)",
+ "uniffi",
+]
+
+[[package]]
+name = "uniffi_bindgen"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a792af1424cc8b3c43b44c1a6cb7935ed1fbe5584a74f70e8bab9799740266d"
+dependencies = [
+ "anyhow",
+ "camino",
+ "cargo_metadata",
+ "fs-err",
+ "glob",
+ "goblin",
+ "heck",
+ "once_cell",
+ "paste",
+ "rinja",
+ "serde",
+ "textwrap",
+ "toml",
+ "uniffi_meta 0.29.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi_udl 0.29.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1469,28 +1479,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "uniffi_bindgen"
-version = "0.29.1"
-source = "git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test#4f7b8119246b19127f02ddb49c82f08f346f44f7"
-dependencies = [
- "anyhow",
- "camino",
- "cargo_metadata",
- "fs-err",
- "glob",
- "goblin",
- "heck",
- "once_cell",
- "paste",
- "rinja",
- "serde",
- "textwrap",
- "toml",
- "uniffi_meta 0.29.1 (git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test)",
- "uniffi_udl 0.29.1 (git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test)",
-]
-
-[[package]]
 name = "uniffi_build"
 version = "0.29.1"
 source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1#82b8c7b557588500b6858291fd9ec8002cdacb36"
@@ -1501,30 +1489,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "uniffi_build"
-version = "0.29.1"
-source = "git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test#4f7b8119246b19127f02ddb49c82f08f346f44f7"
-dependencies = [
- "anyhow",
- "camino",
- "uniffi_bindgen 0.29.1 (git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test)",
-]
-
-[[package]]
 name = "uniffi_core"
 version = "0.29.1"
 source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1#82b8c7b557588500b6858291fd9ec8002cdacb36"
-dependencies = [
- "anyhow",
- "bytes",
- "once_cell",
- "static_assertions",
-]
-
-[[package]]
-name = "uniffi_core"
-version = "0.29.1"
-source = "git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test#4f7b8119246b19127f02ddb49c82f08f346f44f7"
 dependencies = [
  "anyhow",
  "async-compat",
@@ -1536,7 +1503,8 @@ dependencies = [
 [[package]]
 name = "uniffi_internal_macros"
 version = "0.29.1"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1#82b8c7b557588500b6858291fd9ec8002cdacb36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9902d4ed16c65e6c0222241024dd0bfeed07ea3deb7c470eb175e5f5ef406cd"
 dependencies = [
  "quote",
  "syn",
@@ -1545,7 +1513,7 @@ dependencies = [
 [[package]]
 name = "uniffi_internal_macros"
 version = "0.29.1"
-source = "git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test#4f7b8119246b19127f02ddb49c82f08f346f44f7"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1#82b8c7b557588500b6858291fd9ec8002cdacb36"
 dependencies = [
  "quote",
  "syn",
@@ -1568,19 +1536,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "uniffi_macros"
+name = "uniffi_meta"
 version = "0.29.1"
-source = "git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test#4f7b8119246b19127f02ddb49c82f08f346f44f7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d6027b971c2aa86350dd180aee9819729c7b99bacd381534511ff29d2c09cea"
 dependencies = [
- "camino",
- "fs-err",
- "once_cell",
- "proc-macro2",
- "quote",
- "serde",
- "syn",
- "toml",
- "uniffi_meta 0.29.1 (git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test)",
+ "anyhow",
+ "siphasher",
+ "uniffi_internal_macros 0.29.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1591,16 +1554,6 @@ dependencies = [
  "anyhow",
  "siphasher",
  "uniffi_internal_macros 0.29.1 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1)",
-]
-
-[[package]]
-name = "uniffi_meta"
-version = "0.29.1"
-source = "git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test#4f7b8119246b19127f02ddb49c82f08f346f44f7"
-dependencies = [
- "anyhow",
- "siphasher",
- "uniffi_internal_macros 0.29.1 (git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test)",
 ]
 
 [[package]]
@@ -1618,23 +1571,24 @@ dependencies = [
 [[package]]
 name = "uniffi_udl"
 version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52300b7a4ab02dc159a038a13d5bfe27aefbad300d91b0b501b3dda094c1e0a2"
+dependencies = [
+ "anyhow",
+ "textwrap",
+ "uniffi_meta 0.29.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "weedle2 5.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "uniffi_udl"
+version = "0.29.1"
 source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1#82b8c7b557588500b6858291fd9ec8002cdacb36"
 dependencies = [
  "anyhow",
  "textwrap",
  "uniffi_meta 0.29.1 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1)",
  "weedle2 5.0.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1)",
-]
-
-[[package]]
-name = "uniffi_udl"
-version = "0.29.1"
-source = "git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test#4f7b8119246b19127f02ddb49c82f08f346f44f7"
-dependencies = [
- "anyhow",
- "textwrap",
- "uniffi_meta 0.29.1 (git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test)",
- "weedle2 5.0.0 (git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test)",
 ]
 
 [[package]]
@@ -1750,7 +1704,8 @@ dependencies = [
 [[package]]
 name = "weedle2"
 version = "5.0.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1#82b8c7b557588500b6858291fd9ec8002cdacb36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "998d2c24ec099a87daf9467808859f9d82b61f1d9c9701251aea037f514eae0e"
 dependencies = [
  "nom",
 ]
@@ -1758,7 +1713,7 @@ dependencies = [
 [[package]]
 name = "weedle2"
 version = "5.0.0"
-source = "git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test#4f7b8119246b19127f02ddb49c82f08f346f44f7"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1#82b8c7b557588500b6858291fd9ec8002cdacb36"
 dependencies = [
  "nom",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1377,13 +1377,26 @@ version = "0.29.1"
 source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1#82b8c7b557588500b6858291fd9ec8002cdacb36"
 dependencies = [
  "anyhow",
+ "cargo_metadata",
+ "uniffi_bindgen 0.29.1 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1)",
+ "uniffi_build 0.29.1 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1)",
+ "uniffi_core 0.29.1 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1)",
+ "uniffi_macros 0.29.1 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1)",
+]
+
+[[package]]
+name = "uniffi"
+version = "0.29.1"
+source = "git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test#0abd28c353f2a7ef3f1f786d886f0232a72efb42"
+dependencies = [
+ "anyhow",
  "camino",
  "cargo_metadata",
  "clap",
- "uniffi_bindgen 0.29.1 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1)",
- "uniffi_build",
- "uniffi_core",
- "uniffi_macros",
+ "uniffi_bindgen 0.29.1 (git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test)",
+ "uniffi_build 0.29.1 (git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test)",
+ "uniffi_core 0.29.1 (git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test)",
+ "uniffi_macros 0.29.1 (git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test)",
 ]
 
 [[package]]
@@ -1413,8 +1426,8 @@ dependencies = [
  "uniffi-fixture-ext-types",
  "uniffi-fixture-futures",
  "uniffi-fixture-time",
- "uniffi_bindgen 0.29.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "uniffi_meta 0.29.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi_bindgen 0.29.1 (git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test)",
+ "uniffi_meta 0.29.1 (git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test)",
  "uniffi_testing",
 ]
 
@@ -1424,7 +1437,7 @@ version = "0.22.0"
 source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1#82b8c7b557588500b6858291fd9ec8002cdacb36"
 dependencies = [
  "thiserror",
- "uniffi",
+ "uniffi 0.29.1 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1)",
 ]
 
 [[package]]
@@ -1434,7 +1447,7 @@ source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1#82b8c7b557588
 dependencies = [
  "anyhow",
  "bytes",
- "uniffi",
+ "uniffi 0.29.1 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1)",
  "url",
 ]
 
@@ -1445,7 +1458,7 @@ source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1#82b8c7b557588
 dependencies = [
  "async-std",
  "thiserror",
- "uniffi",
+ "uniffi 0.29.1 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1)",
 ]
 
 [[package]]
@@ -1453,7 +1466,7 @@ name = "uniffi-example-geometry"
 version = "0.22.0"
 source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1#82b8c7b557588500b6858291fd9ec8002cdacb36"
 dependencies = [
- "uniffi",
+ "uniffi 0.29.1 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1)",
 ]
 
 [[package]]
@@ -1461,7 +1474,7 @@ name = "uniffi-example-rondpoint"
 version = "0.22.0"
 source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1#82b8c7b557588500b6858291fd9ec8002cdacb36"
 dependencies = [
- "uniffi",
+ "uniffi 0.29.1 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1)",
 ]
 
 [[package]]
@@ -1471,7 +1484,7 @@ source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1#82b8c7b557588
 dependencies = [
  "once_cell",
  "thiserror",
- "uniffi",
+ "uniffi 0.29.1 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1)",
 ]
 
 [[package]]
@@ -1481,7 +1494,7 @@ source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1#82b8c7b557588
 dependencies = [
  "anyhow",
  "bytes",
- "uniffi",
+ "uniffi 0.29.1 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1)",
  "uniffi-example-custom-types",
  "uniffi-fixture-ext-types-custom-types",
  "uniffi-fixture-ext-types-external-crate",
@@ -1498,7 +1511,7 @@ dependencies = [
  "anyhow",
  "bytes",
  "thiserror",
- "uniffi",
+ "uniffi 0.29.1 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1)",
 ]
 
 [[package]]
@@ -1514,7 +1527,7 @@ dependencies = [
  "anyhow",
  "bytes",
  "thiserror",
- "uniffi",
+ "uniffi 0.29.1 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1)",
 ]
 
 [[package]]
@@ -1523,21 +1536,21 @@ version = "0.22.0"
 source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1#82b8c7b557588500b6858291fd9ec8002cdacb36"
 dependencies = [
  "anyhow",
- "uniffi",
+ "uniffi 0.29.1 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1)",
  "uniffi-fixture-ext-types-lib-one",
 ]
 
 [[package]]
 name = "uniffi-fixture-futures"
 version = "0.21.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1#82b8c7b557588500b6858291fd9ec8002cdacb36"
+source = "git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test#0abd28c353f2a7ef3f1f786d886f0232a72efb42"
 dependencies = [
  "async-trait",
  "futures",
  "once_cell",
  "thiserror",
  "tokio",
- "uniffi",
+ "uniffi 0.29.1 (git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test)",
 ]
 
 [[package]]
@@ -1547,30 +1560,7 @@ source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1#82b8c7b557588
 dependencies = [
  "chrono",
  "thiserror",
- "uniffi",
-]
-
-[[package]]
-name = "uniffi_bindgen"
-version = "0.29.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a792af1424cc8b3c43b44c1a6cb7935ed1fbe5584a74f70e8bab9799740266d"
-dependencies = [
- "anyhow",
- "camino",
- "cargo_metadata",
- "fs-err",
- "glob",
- "goblin",
- "heck",
- "once_cell",
- "paste",
- "rinja",
- "serde",
- "textwrap",
- "toml",
- "uniffi_meta 0.29.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "uniffi_udl 0.29.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi 0.29.1 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1)",
 ]
 
 [[package]]
@@ -1596,6 +1586,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "uniffi_bindgen"
+version = "0.29.1"
+source = "git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test#0abd28c353f2a7ef3f1f786d886f0232a72efb42"
+dependencies = [
+ "anyhow",
+ "camino",
+ "cargo_metadata",
+ "fs-err",
+ "glob",
+ "goblin",
+ "heck",
+ "once_cell",
+ "paste",
+ "rinja",
+ "serde",
+ "textwrap",
+ "toml",
+ "uniffi_meta 0.29.1 (git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test)",
+ "uniffi_udl 0.29.1 (git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test)",
+]
+
+[[package]]
 name = "uniffi_build"
 version = "0.29.1"
 source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1#82b8c7b557588500b6858291fd9ec8002cdacb36"
@@ -1606,9 +1618,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "uniffi_build"
+version = "0.29.1"
+source = "git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test#0abd28c353f2a7ef3f1f786d886f0232a72efb42"
+dependencies = [
+ "anyhow",
+ "camino",
+ "uniffi_bindgen 0.29.1 (git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test)",
+]
+
+[[package]]
 name = "uniffi_core"
 version = "0.29.1"
 source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1#82b8c7b557588500b6858291fd9ec8002cdacb36"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "once_cell",
+ "static_assertions",
+]
+
+[[package]]
+name = "uniffi_core"
+version = "0.29.1"
+source = "git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test#0abd28c353f2a7ef3f1f786d886f0232a72efb42"
 dependencies = [
  "anyhow",
  "async-compat",
@@ -1620,8 +1653,7 @@ dependencies = [
 [[package]]
 name = "uniffi_internal_macros"
 version = "0.29.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9902d4ed16c65e6c0222241024dd0bfeed07ea3deb7c470eb175e5f5ef406cd"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1#82b8c7b557588500b6858291fd9ec8002cdacb36"
 dependencies = [
  "quote",
  "syn",
@@ -1630,7 +1662,7 @@ dependencies = [
 [[package]]
 name = "uniffi_internal_macros"
 version = "0.29.1"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1#82b8c7b557588500b6858291fd9ec8002cdacb36"
+source = "git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test#0abd28c353f2a7ef3f1f786d886f0232a72efb42"
 dependencies = [
  "quote",
  "syn",
@@ -1653,14 +1685,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "uniffi_meta"
+name = "uniffi_macros"
 version = "0.29.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d6027b971c2aa86350dd180aee9819729c7b99bacd381534511ff29d2c09cea"
+source = "git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test#0abd28c353f2a7ef3f1f786d886f0232a72efb42"
 dependencies = [
- "anyhow",
- "siphasher",
- "uniffi_internal_macros 0.29.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "camino",
+ "fs-err",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn",
+ "toml",
+ "uniffi_meta 0.29.1 (git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test)",
 ]
 
 [[package]]
@@ -1671,6 +1708,16 @@ dependencies = [
  "anyhow",
  "siphasher",
  "uniffi_internal_macros 0.29.1 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1)",
+]
+
+[[package]]
+name = "uniffi_meta"
+version = "0.29.1"
+source = "git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test#0abd28c353f2a7ef3f1f786d886f0232a72efb42"
+dependencies = [
+ "anyhow",
+ "siphasher",
+ "uniffi_internal_macros 0.29.1 (git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test)",
 ]
 
 [[package]]
@@ -1688,24 +1735,23 @@ dependencies = [
 [[package]]
 name = "uniffi_udl"
 version = "0.29.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52300b7a4ab02dc159a038a13d5bfe27aefbad300d91b0b501b3dda094c1e0a2"
-dependencies = [
- "anyhow",
- "textwrap",
- "uniffi_meta 0.29.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "weedle2 5.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "uniffi_udl"
-version = "0.29.1"
 source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1#82b8c7b557588500b6858291fd9ec8002cdacb36"
 dependencies = [
  "anyhow",
  "textwrap",
  "uniffi_meta 0.29.1 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1)",
  "weedle2 5.0.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1)",
+]
+
+[[package]]
+name = "uniffi_udl"
+version = "0.29.1"
+source = "git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test#0abd28c353f2a7ef3f1f786d886f0232a72efb42"
+dependencies = [
+ "anyhow",
+ "textwrap",
+ "uniffi_meta 0.29.1 (git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test)",
+ "weedle2 5.0.0 (git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test)",
 ]
 
 [[package]]
@@ -1828,8 +1874,7 @@ dependencies = [
 [[package]]
 name = "weedle2"
 version = "5.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "998d2c24ec099a87daf9467808859f9d82b61f1d9c9701251aea037f514eae0e"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1#82b8c7b557588500b6858291fd9ec8002cdacb36"
 dependencies = [
  "nom",
 ]
@@ -1837,7 +1882,7 @@ dependencies = [
 [[package]]
 name = "weedle2"
 version = "5.0.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.1#82b8c7b557588500b6858291fd9ec8002cdacb36"
+source = "git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test#0abd28c353f2a7ef3f1f786d886f0232a72efb42"
 dependencies = [
  "nom",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1270,7 +1270,7 @@ dependencies = [
 [[package]]
 name = "uniffi"
 version = "0.29.1"
-source = "git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test#1487059daabe8f5434cddfd6b9dce48174651bf7"
+source = "git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test#ed171f298b4251f7a463088b5a4fb375f38f28d2"
 dependencies = [
  "anyhow",
  "camino",
@@ -1426,7 +1426,7 @@ dependencies = [
 [[package]]
 name = "uniffi-fixture-futures"
 version = "0.21.0"
-source = "git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test#1487059daabe8f5434cddfd6b9dce48174651bf7"
+source = "git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test#ed171f298b4251f7a463088b5a4fb375f38f28d2"
 dependencies = [
  "async-trait",
  "futures",
@@ -1471,7 +1471,7 @@ dependencies = [
 [[package]]
 name = "uniffi_bindgen"
 version = "0.29.1"
-source = "git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test#1487059daabe8f5434cddfd6b9dce48174651bf7"
+source = "git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test#ed171f298b4251f7a463088b5a4fb375f38f28d2"
 dependencies = [
  "anyhow",
  "camino",
@@ -1503,7 +1503,7 @@ dependencies = [
 [[package]]
 name = "uniffi_build"
 version = "0.29.1"
-source = "git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test#1487059daabe8f5434cddfd6b9dce48174651bf7"
+source = "git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test#ed171f298b4251f7a463088b5a4fb375f38f28d2"
 dependencies = [
  "anyhow",
  "camino",
@@ -1524,7 +1524,7 @@ dependencies = [
 [[package]]
 name = "uniffi_core"
 version = "0.29.1"
-source = "git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test#1487059daabe8f5434cddfd6b9dce48174651bf7"
+source = "git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test#ed171f298b4251f7a463088b5a4fb375f38f28d2"
 dependencies = [
  "anyhow",
  "async-compat",
@@ -1545,7 +1545,7 @@ dependencies = [
 [[package]]
 name = "uniffi_internal_macros"
 version = "0.29.1"
-source = "git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test#1487059daabe8f5434cddfd6b9dce48174651bf7"
+source = "git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test#ed171f298b4251f7a463088b5a4fb375f38f28d2"
 dependencies = [
  "quote",
  "syn",
@@ -1570,7 +1570,7 @@ dependencies = [
 [[package]]
 name = "uniffi_macros"
 version = "0.29.1"
-source = "git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test#1487059daabe8f5434cddfd6b9dce48174651bf7"
+source = "git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test#ed171f298b4251f7a463088b5a4fb375f38f28d2"
 dependencies = [
  "camino",
  "fs-err",
@@ -1596,7 +1596,7 @@ dependencies = [
 [[package]]
 name = "uniffi_meta"
 version = "0.29.1"
-source = "git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test#1487059daabe8f5434cddfd6b9dce48174651bf7"
+source = "git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test#ed171f298b4251f7a463088b5a4fb375f38f28d2"
 dependencies = [
  "anyhow",
  "siphasher",
@@ -1629,7 +1629,7 @@ dependencies = [
 [[package]]
 name = "uniffi_udl"
 version = "0.29.1"
-source = "git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test#1487059daabe8f5434cddfd6b9dce48174651bf7"
+source = "git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test#ed171f298b4251f7a463088b5a4fb375f38f28d2"
 dependencies = [
  "anyhow",
  "textwrap",
@@ -1758,7 +1758,7 @@ dependencies = [
 [[package]]
 name = "weedle2"
 version = "5.0.0"
-source = "git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test#1487059daabe8f5434cddfd6b9dce48174651bf7"
+source = "git+https://github.com/skeet70/uniffi-rs.git?branch=noisy-test#ed171f298b4251f7a463088b5a4fb375f38f28d2"
 dependencies = [
  "nom",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,9 +48,9 @@ serde = "1"
 textwrap = "0.16.1"
 toml = "0.5" # can't be on 8, `Value` is part of public interface
 # uniffi_bindgen = "0.29.1"
-uniffi_bindgen = { git = "https://github.com/skeet70/uniffi-rs.git", branch = "noisy-test"}
+uniffi_bindgen = { git = "https://github.com/skeet70/uniffi-rs.git", branch = "noisy-test" }
 # uniffi_meta = "0.29.1"
-uniffi_meta = { git = "https://github.com/skeet70/uniffi-rs.git", branch = "noisy-test"}
+uniffi_meta = { git = "https://github.com/skeet70/uniffi-rs.git", branch = "noisy-test" }
 
 [dev-dependencies]
 glob = "0.3"
@@ -63,6 +63,6 @@ uniffi-example-rondpoint = { git = "https://github.com/mozilla/uniffi-rs.git", t
 uniffi-fixture-coverall = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.29.1" }
 uniffi-fixture-ext-types = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.29.1" }
 # uniffi-fixture-futures = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.29.1" }
-uniffi-fixture-futures = { git = "https://github.com/skeet70/uniffi-rs.git", branch = "noisy-test"}
+uniffi-fixture-futures = { git = "https://github.com/skeet70/uniffi-rs.git", branch = "noisy-test" }
 uniffi-fixture-time = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.29.1" }
 uniffi_testing = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.29.1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,8 +47,10 @@ rinja = { version = "0.3", default-features = false, features = ["config"] }
 serde = "1"
 textwrap = "0.16.1"
 toml = "0.5" # can't be on 8, `Value` is part of public interface
-uniffi_bindgen = "0.29.1"
-uniffi_meta = "0.29.1"
+# uniffi_bindgen = "0.29.1"
+uniffi_bindgen = { git = "https://github.com/skeet70/uniffi-rs.git", branch = "noisy-test"}
+# uniffi_meta = "0.29.1"
+uniffi_meta = { git = "https://github.com/skeet70/uniffi-rs.git", branch = "noisy-test"}
 
 [dev-dependencies]
 glob = "0.3"
@@ -60,6 +62,7 @@ uniffi-example-geometry = { git = "https://github.com/mozilla/uniffi-rs.git", ta
 uniffi-example-rondpoint = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.29.1" }
 uniffi-fixture-coverall = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.29.1" }
 uniffi-fixture-ext-types = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.29.1" }
-uniffi-fixture-futures = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.29.1" }
+# uniffi-fixture-futures = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.29.1" }
+uniffi-fixture-futures = { git = "https://github.com/skeet70/uniffi-rs.git", branch = "noisy-test"}
 uniffi-fixture-time = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.29.1" }
 uniffi_testing = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.29.1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,6 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow = "1"
-rinja = { version = "0.3", default-features = false, features = ["config"] }
 camino = "1.1.6"
 cargo_metadata = "0.15"
 clap = { version = "4", default-features = false, features = [
@@ -44,6 +43,7 @@ heck = "0.5"
 once_cell = "1.19.0"
 paste = "1"
 regex = "1.10.4"
+rinja = { version = "0.3", default-features = false, features = ["config"] }
 serde = "1"
 textwrap = "0.16.1"
 toml = "0.5" # can't be on 8, `Value` is part of public interface

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,10 +47,8 @@ rinja = { version = "0.3", default-features = false, features = ["config"] }
 serde = "1"
 textwrap = "0.16.1"
 toml = "0.5" # can't be on 8, `Value` is part of public interface
-# uniffi_bindgen = "0.29.1"
-uniffi_bindgen = { git = "https://github.com/skeet70/uniffi-rs.git", branch = "noisy-test" }
-# uniffi_meta = "0.29.1"
-uniffi_meta = { git = "https://github.com/skeet70/uniffi-rs.git", branch = "noisy-test" }
+uniffi_bindgen = "0.29.1"
+uniffi_meta = "0.29.1"
 
 [dev-dependencies]
 glob = "0.3"
@@ -62,7 +60,6 @@ uniffi-example-geometry = { git = "https://github.com/mozilla/uniffi-rs.git", ta
 uniffi-example-rondpoint = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.29.1" }
 uniffi-fixture-coverall = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.29.1" }
 uniffi-fixture-ext-types = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.29.1" }
-# uniffi-fixture-futures = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.29.1" }
-uniffi-fixture-futures = { git = "https://github.com/skeet70/uniffi-rs.git", branch = "noisy-test" }
+uniffi-fixture-futures = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.29.1" }
 uniffi-fixture-time = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.29.1" }
 uniffi_testing = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.29.1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,8 +47,10 @@ rinja = { version = "0.3", default-features = false, features = ["config"] }
 serde = "1"
 textwrap = "0.16.1"
 toml = "0.5" # can't be on 8, `Value` is part of public interface
-uniffi_bindgen = "0.29.1"
-uniffi_meta = "0.29.1"
+# uniffi_bindgen = "0.29.1"
+uniffi_bindgen = { git = "https://github.com/skeet70/uniffi-rs.git", branch = "noisy-test" }
+# uniffi_meta = "0.29.1"
+uniffi_meta = { git = "https://github.com/skeet70/uniffi-rs.git", branch = "noisy-test" }
 
 [dev-dependencies]
 glob = "0.3"
@@ -60,6 +62,7 @@ uniffi-example-geometry = { git = "https://github.com/mozilla/uniffi-rs.git", ta
 uniffi-example-rondpoint = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.29.1" }
 uniffi-fixture-coverall = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.29.1" }
 uniffi-fixture-ext-types = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.29.1" }
-uniffi-fixture-futures = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.29.1" }
+# uniffi-fixture-futures = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.29.1" }
+uniffi-fixture-futures = { git = "https://github.com/skeet70/uniffi-rs.git", branch = "noisy-test" }
 uniffi-fixture-time = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.29.1" }
 uniffi_testing = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.29.1" }

--- a/src/gen_java/callback_interface.rs
+++ b/src/gen_java/callback_interface.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use super::{potentially_add_external_package, CodeType, Config};
+use super::{CodeType, Config, potentially_add_external_package};
 use crate::ComponentInterface;
 
 #[derive(Debug)]

--- a/src/gen_java/compounds.rs
+++ b/src/gen_java/compounds.rs
@@ -4,8 +4,8 @@
 
 use super::{AsCodeType, CodeType, Config};
 use uniffi_bindgen::{
-    backend::{Literal, Type},
     ComponentInterface,
+    backend::{Literal, Type},
 };
 
 #[derive(Debug)]

--- a/src/gen_java/custom.rs
+++ b/src/gen_java/custom.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use super::{potentially_add_external_package, CodeType, Config};
+use super::{CodeType, Config, potentially_add_external_package};
 use crate::ComponentInterface;
 
 #[derive(Debug)]

--- a/src/gen_java/enum_.rs
+++ b/src/gen_java/enum_.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use super::{potentially_add_external_package, CodeType, Config};
+use super::{CodeType, Config, potentially_add_external_package};
 use crate::ComponentInterface;
 use uniffi_bindgen::backend::Literal;
 

--- a/src/gen_java/object.rs
+++ b/src/gen_java/object.rs
@@ -2,8 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use super::{potentially_add_external_package, CodeType, Config};
-use uniffi_bindgen::{interface::ObjectImpl, ComponentInterface};
+use super::{CodeType, Config, potentially_add_external_package};
+use uniffi_bindgen::{ComponentInterface, interface::ObjectImpl};
 
 #[derive(Debug)]
 pub struct ObjectCodeType {

--- a/src/gen_java/record.rs
+++ b/src/gen_java/record.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use super::{potentially_add_external_package, CodeType, Config};
+use super::{CodeType, Config, potentially_add_external_package};
 use uniffi_bindgen::ComponentInterface;
 
 #[derive(Debug)]

--- a/src/gen_java/variant.rs
+++ b/src/gen_java/variant.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use super::{potentially_add_external_package, AsCodeType, CodeType, Config, JavaCodeOracle};
+use super::{AsCodeType, CodeType, Config, JavaCodeOracle, potentially_add_external_package};
 use uniffi_bindgen::interface::{ComponentInterface, Variant};
 
 #[derive(Debug)]

--- a/src/templates/Async.java
+++ b/src/templates/Async.java
@@ -145,6 +145,7 @@ public final class UniffiAsyncHelpers {
         Consumer<T> handleSuccess,
         Consumer<UniffiRustCallStatus.ByValue> handleError 
     ){
+        System.out.println("Calling trait interface async");
         // Uniffi does its best to support structured concurrency across the FFI.
         // If the Rust future is dropped, `UniffiForeignFutureFreeImpl` is called, which will cancel the Java completable future if it's still running.
         var foreignFutureCf = makeCall.get();

--- a/src/templates/Async.java
+++ b/src/templates/Async.java
@@ -217,6 +217,7 @@ public final class UniffiAsyncHelpers {
 
         @Override
         public void callback(long handle) {
+            System.out.println("java free impl called");
             var job = uniffiForeignFutureHandleMap.remove(handle);
             var successfullyCancelled = job.cancel(true);
             if(successfullyCancelled) {

--- a/src/templates/Async.java
+++ b/src/templates/Async.java
@@ -131,7 +131,7 @@ public final class UniffiAsyncHelpers {
         CompletableFuture<Byte> pollFuture = new CompletableFuture<>();
         var handle = uniffiContinuationHandleMap.insert(pollFuture);
         pollFunc.apply(rustFuture, UniffiRustFutureContinuationCallbackImpl.INSTANCE, handle);
-
+        // do {} while (!pollFuture.isDone());
         return pollFuture.get();
     }
     

--- a/src/templates/Async.java
+++ b/src/templates/Async.java
@@ -135,10 +135,6 @@ public final class UniffiAsyncHelpers {
         var handle = uniffiContinuationHandleMap.insert(pollFuture);
         pollFunc.apply(rustFuture, UniffiRustFutureContinuationCallbackImpl.INSTANCE, handle);
 
-        // busy-wait until the poll completes
-        // TODO(java): may be more efficient to use a CountdownLatch here instead of a CF we end up busy-waiting
-        //     because of Java bugs.
-        do {} while (!pollFuture.isDone());
         return pollFuture.get();
     }
     

--- a/src/templates/Async.java
+++ b/src/templates/Async.java
@@ -182,7 +182,6 @@ public final class UniffiAsyncHelpers {
 
             return null;
         });
-        // if we don't add the free impl to something static, it could be GCd before Rust calls for free
         long handle = uniffiForeignFutureHandleMap.insert(new CancelableForeignFuture(foreignFutureCf, ffHandler));
         return new UniffiForeignFuture(handle, UniffiForeignFutureFreeImpl.INSTANCE);
     }

--- a/src/templates/Async.java
+++ b/src/templates/Async.java
@@ -222,6 +222,7 @@ public final class UniffiAsyncHelpers {
 
         @Override
         public void callback(long handle) {
+            System.out.println("free called " + System.currentTimeMillis());
             var job = uniffiForeignFutureHandleMap.remove(handle);
             var successfullyCancelled = job.cancel(true);
             if(successfullyCancelled) {

--- a/src/templates/Async.java
+++ b/src/templates/Async.java
@@ -184,6 +184,7 @@ public final class UniffiAsyncHelpers {
             try {
                 foreignFutureCf.thenAcceptAsync(handleSuccess).get();
             } catch (Throwable e) {
+                System.out.println("caught error in call to java trait from rust " + System.currentTimeMillis());
                 // if we errored inside the CF, it's that error we want to send to Rust, not the wrapper
                 if (e instanceof ExecutionException) {
                     e = e.getCause();

--- a/src/templates/Async.java
+++ b/src/templates/Async.java
@@ -22,6 +22,7 @@ public final class UniffiAsyncHelpers {
         @Override
         public void callback(long data, byte pollResult) {
             uniffiContinuationHandleMap.remove(data).complete(pollResult);
+            System.out.println("java completed continuation " + System.currentTimeMillis());
         }
     }
 
@@ -63,6 +64,7 @@ public final class UniffiAsyncHelpers {
             try {
                 byte pollResult;
                 do {
+                    System.out.println("java loop polling rust future " + System.currentTimeMillis());
                     pollResult = poll(rustFuture, pollFunc);
                 } while (pollResult != UNIFFI_RUST_FUTURE_POLL_READY);
 

--- a/src/templates/Async.java
+++ b/src/templates/Async.java
@@ -21,7 +21,6 @@ public final class UniffiAsyncHelpers {
 
         @Override
         public void callback(long data, byte pollResult) {
-            System.out.println("java completed continuation " + System.currentTimeMillis());
             uniffiContinuationHandleMap.remove(data).complete(pollResult);
         }
     }
@@ -185,7 +184,6 @@ public final class UniffiAsyncHelpers {
         });
         // if we don't add the free impl to something static, it could be GCd before Rust calls for free
         long handle = uniffiForeignFutureHandleMap.insert(new CancelableForeignFuture(foreignFutureCf, ffHandler));
-        System.out.println("java async trait inserted Handle(" + handle + ") " + System.currentTimeMillis());
         return new UniffiForeignFuture(handle, UniffiForeignFutureFreeImpl.INSTANCE);
     }
 
@@ -227,32 +225,16 @@ public final class UniffiAsyncHelpers {
         });
 
         long handle = uniffiForeignFutureHandleMap.insert(new CancelableForeignFuture(foreignFutureCf, ffHandler));
-        System.out.println("java async trait w/error inserted Handle(" + handle + ") " + System.currentTimeMillis());
         return new UniffiForeignFuture(handle, UniffiForeignFutureFreeImpl.INSTANCE);
     }
 
-    static class UniffiForeignFutureFreeImpl implements UniffiForeignFutureFree {
-        public static final UniffiForeignFutureFreeImpl INSTANCE = new UniffiForeignFutureFreeImpl();
-
-        // private to enforce singleton
-        private UniffiForeignFutureFreeImpl() {}
+    enum UniffiForeignFutureFreeImpl implements UniffiForeignFutureFree {
+        INSTANCE;
 
         @Override
         public void callback(long handle) {
-            System.out.println("java free impl called Handle(" + handle + ") " + System.currentTimeMillis());
             var futureWithHandler = uniffiForeignFutureHandleMap.remove(handle);
             futureWithHandler.cancel();
-        }
-
-        /**
-        * @deprecated override deprecated method
-        */
-        @Deprecated
-        @Override
-        @SuppressWarnings("removal")
-        protected void finalize() throws Throwable {
-            System.out.println("🔥 UniffiForeignFutureFreeImpl was GC'd!");
-            super.finalize();
         }
     }
 

--- a/src/templates/Async.java
+++ b/src/templates/Async.java
@@ -145,7 +145,6 @@ public final class UniffiAsyncHelpers {
         Consumer<T> handleSuccess,
         Consumer<UniffiRustCallStatus.ByValue> handleError 
     ){
-        System.out.println("Calling trait interface async");
         // Uniffi does its best to support structured concurrency across the FFI.
         // If the Rust future is dropped, `UniffiForeignFutureFreeImpl` is called, which will cancel the Java completable future if it's still running.
         var foreignFutureCf = makeCall.get();

--- a/src/templates/Async.java
+++ b/src/templates/Async.java
@@ -165,6 +165,7 @@ public final class UniffiAsyncHelpers {
         });
         
         long handle = uniffiForeignFutureHandleMap.insert(job);
+        System.out.println("java async trait inserted Handle(" + handle + ") " + System.currentTimeMillis());
         return new UniffiForeignFuture(handle, new UniffiForeignFutureFreeImpl<T>(foreignFutureCf));
     }
 
@@ -206,6 +207,7 @@ public final class UniffiAsyncHelpers {
         });
 
         long handle = uniffiForeignFutureHandleMap.insert(job);
+        System.out.println("java async trait w/error inserted Handle(" + handle + ") " + System.currentTimeMillis());
         return new UniffiForeignFuture(handle, new UniffiForeignFutureFreeImpl<T>(foreignFutureCf));
     }
 

--- a/src/templates/Async.java
+++ b/src/templates/Async.java
@@ -131,7 +131,7 @@ public final class UniffiAsyncHelpers {
         CompletableFuture<Byte> pollFuture = new CompletableFuture<>();
         var handle = uniffiContinuationHandleMap.insert(pollFuture);
         pollFunc.apply(rustFuture, UniffiRustFutureContinuationCallbackImpl.INSTANCE, handle);
-        // do {} while (!pollFuture.isDone());
+        do {} while (!pollFuture.isDone()); // removing this makes futures not cancel (sometimes)
         return pollFuture.get();
     }
     

--- a/src/templates/Async.java
+++ b/src/templates/Async.java
@@ -22,7 +22,6 @@ public final class UniffiAsyncHelpers {
         @Override
         public void callback(long data, byte pollResult) {
             uniffiContinuationHandleMap.remove(data).complete(pollResult);
-            System.out.println("java completed continuation " + System.currentTimeMillis());
         }
     }
 
@@ -64,9 +63,7 @@ public final class UniffiAsyncHelpers {
             try {
                 byte pollResult;
                 do {
-                    System.out.println("java loop polling rust future " + System.currentTimeMillis());
                     pollResult = poll(rustFuture, pollFunc);
-                    System.out.println("java loop finished polling rust future " + System.currentTimeMillis());
                 } while (pollResult != UNIFFI_RUST_FUTURE_POLL_READY);
 
                 if (!future.isCancelled()) {
@@ -183,7 +180,6 @@ public final class UniffiAsyncHelpers {
             try {
                 foreignFutureCf.thenAcceptAsync(handleSuccess).get();
             } catch (Throwable e) {
-                System.out.println("caught error in call to java trait from rust " + System.currentTimeMillis());
                 // if we errored inside the CF, it's that error we want to send to Rust, not the wrapper
                 if (e instanceof ExecutionException) {
                     e = e.getCause();
@@ -221,7 +217,6 @@ public final class UniffiAsyncHelpers {
 
         @Override
         public void callback(long handle) {
-            System.out.println("free called " + System.currentTimeMillis());
             var job = uniffiForeignFutureHandleMap.remove(handle);
             var successfullyCancelled = job.cancel(true);
             if(successfullyCancelled) {

--- a/src/templates/Async.java
+++ b/src/templates/Async.java
@@ -228,7 +228,12 @@ public final class UniffiAsyncHelpers {
             }
         }
 
+        /**
+        * @deprecated override deprecated method
+        */
+        @Deprecated
         @Override
+        @SuppressWarnings("removal")
         protected void finalize() throws Throwable {
             System.out.println("🔥 UniffiForeignFutureFreeImpl was GC'd!");
             super.finalize();

--- a/src/templates/Async.java
+++ b/src/templates/Async.java
@@ -66,6 +66,7 @@ public final class UniffiAsyncHelpers {
                 do {
                     System.out.println("java loop polling rust future " + System.currentTimeMillis());
                     pollResult = poll(rustFuture, pollFunc);
+                    System.out.println("java loop finished polling rust future " + System.currentTimeMillis());
                 } while (pollResult != UNIFFI_RUST_FUTURE_POLL_READY);
 
                 if (!future.isCancelled()) {

--- a/src/templates/Async.java
+++ b/src/templates/Async.java
@@ -227,6 +227,12 @@ public final class UniffiAsyncHelpers {
                 childFuture.cancel(true);
             }
         }
+
+        @Override
+        protected void finalize() throws Throwable {
+            System.out.println("🔥 UniffiForeignFutureFreeImpl was GC'd!");
+            super.finalize();
+        }
     }
 
     // For testing

--- a/src/templates/Async.java
+++ b/src/templates/Async.java
@@ -217,7 +217,7 @@ public final class UniffiAsyncHelpers {
 
         @Override
         public void callback(long handle) {
-            System.out.println("java free impl called");
+            System.out.println("java free impl called Handle(" + handle + ") " + System.currentTimeMillis());
             var job = uniffiForeignFutureHandleMap.remove(handle);
             var successfullyCancelled = job.cancel(true);
             if(successfullyCancelled) {

--- a/src/templates/Async.java
+++ b/src/templates/Async.java
@@ -21,6 +21,7 @@ public final class UniffiAsyncHelpers {
 
         @Override
         public void callback(long data, byte pollResult) {
+            System.out.println("java completed continuation " + System.currentTimeMillis());
             uniffiContinuationHandleMap.remove(data).complete(pollResult);
         }
     }

--- a/tests/scripts/TestFixtureFutures/TestFixtureFutures.java
+++ b/tests/scripts/TestFixtureFutures/TestFixtureFutures.java
@@ -47,136 +47,136 @@ public class TestFixtureFutures {
 
   public static void main(String[] args) throws Exception {
     try {
-      // // init UniFFI to get good measurements after that
-      // {
-      //   var time = measureTimeMillis(() -> {
-      //       Futures.alwaysReady().get();
-      //   });
+      // init UniFFI to get good measurements after that
+      {
+        var time = measureTimeMillis(() -> {
+            Futures.alwaysReady().get();
+        });
 
-      //   System.out.println(MessageFormat.format("init time: {0}ms", time));
-      // }
+        System.out.println(MessageFormat.format("init time: {0}ms", time));
+      }
 
-      // // Test `always_ready`
-      // {
-      //   var time = measureTimeMillis(() -> {
-      //       var result = Futures.alwaysReady().get();
-      //       assert result.equals(true);
-      //   });
+      // Test `always_ready`
+      {
+        var time = measureTimeMillis(() -> {
+            var result = Futures.alwaysReady().get();
+            assert result.equals(true);
+        });
 
-      //   assertReturnsImmediately(time, "always_ready");
-      // }
+        assertReturnsImmediately(time, "always_ready");
+      }
 
-      // // Test `void`.
-      // {
-      //   var time = measureTimeMillis(() -> {
-      //     var result = Futures._void().get();
+      // Test `void`.
+      {
+        var time = measureTimeMillis(() -> {
+          var result = Futures._void().get();
 
-      //     assert result == null;
-      //   });
+          assert result == null;
+        });
 
-      //   assertReturnsImmediately(time, "void");
-      // }
+        assertReturnsImmediately(time, "void");
+      }
 
-      // // Test `sleep`.
-      // {
-      //   var time = measureTimeMillis(() -> {
-      //     Futures.sleep((short)200).get();
-      //   });
+      // Test `sleep`.
+      {
+        var time = measureTimeMillis(() -> {
+          Futures.sleep((short)200).get();
+        });
 
-      //   assertApproximateTime(time, 200, "sleep");
-      // }
+        assertApproximateTime(time, 200, "sleep");
+      }
     
-      // // Test sequential futures.
-      // {
-      //   var time = measureTimeMillis(() -> {
-      //     var aliceResult = Futures.sayAfter((short)100, "Alice").get();
-      //     var bobResult = Futures.sayAfter((short)200, "Bob").get();
+      // Test sequential futures.
+      {
+        var time = measureTimeMillis(() -> {
+          var aliceResult = Futures.sayAfter((short)100, "Alice").get();
+          var bobResult = Futures.sayAfter((short)200, "Bob").get();
 
-      //     assert aliceResult.equals("Hello, Alice!");
-      //     assert bobResult.equals("Hello, Bob!");
-      //   });
+          assert aliceResult.equals("Hello, Alice!");
+          assert bobResult.equals("Hello, Bob!");
+        });
 
-      //   assertApproximateTime(time, 300, "sequential future");
-      // }
+        assertApproximateTime(time, 300, "sequential future");
+      }
 
-      // // Test concurrent futures.
-      // {
-      //   var time = measureTimeMillis(() -> {
-      //     var alice = Futures.sayAfter((short)100, "Alice");
-      //     var bob = Futures.sayAfter((short)200, "Bob");
+      // Test concurrent futures.
+      {
+        var time = measureTimeMillis(() -> {
+          var alice = Futures.sayAfter((short)100, "Alice");
+          var bob = Futures.sayAfter((short)200, "Bob");
 
-      //     assert alice.get().equals("Hello, Alice!");
-      //     assert bob.get().equals("Hello, Bob!");
-      //   });
+          assert alice.get().equals("Hello, Alice!");
+          assert bob.get().equals("Hello, Bob!");
+        });
     
-      //   assertApproximateTime(time, 200, "concurrent future");
-      // }
+        assertApproximateTime(time, 200, "concurrent future");
+      }
 
-      // // Test async methods.
-      // {
-      //   var megaphone = Futures.newMegaphone();
-      //   var time = measureTimeMillis(() -> {
-      //     var resultAlice = megaphone.sayAfter((short)200, "Alice").get();
+      // Test async methods.
+      {
+        var megaphone = Futures.newMegaphone();
+        var time = measureTimeMillis(() -> {
+          var resultAlice = megaphone.sayAfter((short)200, "Alice").get();
 
-      //     assert resultAlice.equals("HELLO, ALICE!");
-      //   });
+          assert resultAlice.equals("HELLO, ALICE!");
+        });
 
-      //   assertApproximateTime(time, 200, "async methods");
-      // }
+        assertApproximateTime(time, 200, "async methods");
+      }
 
-      // {
-      //   var megaphone = Futures.newMegaphone();
-      //   var time = measureTimeMillis(() -> {
-      //     var resultAlice = Futures.sayAfterWithMegaphone(megaphone, (short)200, "Alice").get();
+      {
+        var megaphone = Futures.newMegaphone();
+        var time = measureTimeMillis(() -> {
+          var resultAlice = Futures.sayAfterWithMegaphone(megaphone, (short)200, "Alice").get();
 
-      //     assert resultAlice.equals("HELLO, ALICE!");
-      //   });
+          assert resultAlice.equals("HELLO, ALICE!");
+        });
 
-      //   assertApproximateTime(time, 200, "async methods");
-      // }
+        assertApproximateTime(time, 200, "async methods");
+      }
 
-      // // Test async constructors
-      // {
-      //   var megaphone = Megaphone.secondary().get();
-      //   assert megaphone.sayAfter((short)1, "hi").get().equals("HELLO, HI!");
-      // }
+      // Test async constructors
+      {
+        var megaphone = Megaphone.secondary().get();
+        assert megaphone.sayAfter((short)1, "hi").get().equals("HELLO, HI!");
+      }
 
-      // // Test async method returning optional object
-      // {
-      //   var megaphone = Futures.asyncMaybeNewMegaphone(true).get();
-      //   assert megaphone != null;
+      // Test async method returning optional object
+      {
+        var megaphone = Futures.asyncMaybeNewMegaphone(true).get();
+        assert megaphone != null;
     
-      //   var not_megaphone = Futures.asyncMaybeNewMegaphone(false).get();
-      //   assert not_megaphone == null;
-      // }
+        var not_megaphone = Futures.asyncMaybeNewMegaphone(false).get();
+        assert not_megaphone == null;
+      }
 
-      // // Test async methods in trait interfaces
-      // {
-      //   var traits = Futures.getSayAfterTraits();
-      //   var time = measureTimeMillis(() -> {
-      //     var result1 = traits.get(0).sayAfter((short)100, "Alice").get();
-      //     var result2 = traits.get(1).sayAfter((short)100, "Bob").get();
+      // Test async methods in trait interfaces
+      {
+        var traits = Futures.getSayAfterTraits();
+        var time = measureTimeMillis(() -> {
+          var result1 = traits.get(0).sayAfter((short)100, "Alice").get();
+          var result2 = traits.get(1).sayAfter((short)100, "Bob").get();
 
-      //     assert result1.equals("Hello, Alice!");
-      //     assert result2.equals("Hello, Bob!");
-      //   });
+          assert result1.equals("Hello, Alice!");
+          assert result2.equals("Hello, Bob!");
+        });
 
-      //   assertApproximateTime(time, 200, "async trait methods");
-      // }
+        assertApproximateTime(time, 200, "async trait methods");
+      }
 
-      // // Test async methods in UDL-defined trait interfaces
-      // {
-      //   var traits = Futures.getSayAfterUdlTraits();
-      //   var time = measureTimeMillis(() -> {
-      //     var result1 = traits.get(0).sayAfter((short)100, "Alice").get();
-      //     var result2 = traits.get(1).sayAfter((short)100, "Bob").get();
+      // Test async methods in UDL-defined trait interfaces
+      {
+        var traits = Futures.getSayAfterUdlTraits();
+        var time = measureTimeMillis(() -> {
+          var result1 = traits.get(0).sayAfter((short)100, "Alice").get();
+          var result2 = traits.get(1).sayAfter((short)100, "Bob").get();
 
-      //     assert result1.equals("Hello, Alice!");
-      //     assert result2.equals("Hello, Bob!");
-      //   });
+          assert result1.equals("Hello, Alice!");
+          assert result2.equals("Hello, Bob!");
+        });
 
-      //   assertApproximateTime(time, 200, "async UDL methods");
-      // }
+        assertApproximateTime(time, 200, "async UDL methods");
+      }
 
       // Test foreign implemented async trait methods
       {
@@ -233,189 +233,186 @@ public class TestFixtureFutures {
         }
 
         var traitObj = new JavaAsyncParser();
-        // assert Futures.asStringUsingTrait(traitObj, 1, 42).get().equals("42");
-        System.out.println("java test calling for trait method " + System.currentTimeMillis());
+        assert Futures.asStringUsingTrait(traitObj, 1, 42).get().equals("42");
         assert Futures.tryFromStringUsingTrait(traitObj, 1, "42").get().equals(42);
-        System.out.println("java test finished trait method " + System.currentTimeMillis());
-        // try {
-        //   Futures.tryFromStringUsingTrait(traitObj, 1, "fourty-two").get();
-        //   throw new RuntimeException("Expected last statement to throw");
-        // } catch (ExecutionException e) {
-        //   if (e.getCause() instanceof ParserException.NotAnInt) {
-        //       // Expected
-        //   } else {
-        //     throw e;
-        //   }
-        // }
-        // try {
-        //   Futures.tryFromStringUsingTrait(traitObj, 1, "force-unexpected-exception").get();
-        //   throw new RuntimeException("Expected last statement to throw");
-        // } catch (ExecutionException e) {
-        //   if (e.getCause() instanceof ParserException.UnexpectedException) {
-        //      // Expected
-        //   } else {
-        //      throw e;
-        //   }
-        // }
-        // Futures.delayUsingTrait(traitObj, 1).get();
-        // try {
-        //   Futures.tryDelayUsingTrait(traitObj, "one").get();
-        //   throw new RuntimeException("Expected last statement to throw");
-        // } catch (ExecutionException e) {
-        //   if (e.getCause() instanceof ParserException.NotAnInt) {
-        //     // Expected
-        //   } else {
-        //     throw e;
-        //   }
-        // }
-        // var completedDelaysBefore = traitObj.completedDelays;
-        // Futures.cancelDelayUsingTrait(traitObj, 50).get();
-        // // sleep long enough so that the `delay()` call would finish if it wasn't cancelled.
-        // TestFixtureFutures.delay(200).get();
-        // // If the task was cancelled, then completedDelays won't have increased
-        // assert traitObj.completedDelays == completedDelaysBefore : MessageFormat.format("{0} current delays != {1} delays before", traitObj.completedDelays, completedDelaysBefore);
+        try {
+          Futures.tryFromStringUsingTrait(traitObj, 1, "fourty-two").get();
+          throw new RuntimeException("Expected last statement to throw");
+        } catch (ExecutionException e) {
+          if (e.getCause() instanceof ParserException.NotAnInt) {
+              // Expected
+          } else {
+            throw e;
+          }
+        }
+        try {
+          Futures.tryFromStringUsingTrait(traitObj, 1, "force-unexpected-exception").get();
+          throw new RuntimeException("Expected last statement to throw");
+        } catch (ExecutionException e) {
+          if (e.getCause() instanceof ParserException.UnexpectedException) {
+             // Expected
+          } else {
+             throw e;
+          }
+        }
+        Futures.delayUsingTrait(traitObj, 1).get();
+        try {
+          Futures.tryDelayUsingTrait(traitObj, "one").get();
+          throw new RuntimeException("Expected last statement to throw");
+        } catch (ExecutionException e) {
+          if (e.getCause() instanceof ParserException.NotAnInt) {
+            // Expected
+          } else {
+            throw e;
+          }
+        }
+        var completedDelaysBefore = traitObj.completedDelays;
+        Futures.cancelDelayUsingTrait(traitObj, 50).get();
+        // sleep long enough so that the `delay()` call would finish if it wasn't cancelled.
+        TestFixtureFutures.delay(200).get();
+        // If the task was cancelled, then completedDelays won't have increased
+        assert traitObj.completedDelays == completedDelaysBefore : MessageFormat.format("{0} current delays != {1} delays before", traitObj.completedDelays, completedDelaysBefore);
 
         // Test that all handles were cleaned up
-        System.gc();
         var endingHandleCount = UniffiAsyncHelpers.uniffiForeignFutureHandleCount();
         System.out.println("got handle count " + System.currentTimeMillis());
         assert endingHandleCount == 0 : MessageFormat.format("{0} current handle count != 0", endingHandleCount);
       }
 
-      // // Test with the Tokio runtime.
-      // {
-      //   var time = measureTimeMillis(() -> {
-      //     var resultAlice = Futures.sayAfterWithTokio((short)200, "Alice").get();
+      // Test with the Tokio runtime.
+      {
+        var time = measureTimeMillis(() -> {
+          var resultAlice = Futures.sayAfterWithTokio((short)200, "Alice").get();
 
-      //     assert resultAlice.equals("Hello, Alice (with Tokio)!");
-      //   });
+          assert resultAlice.equals("Hello, Alice (with Tokio)!");
+        });
 
-      //   assertApproximateTime(time, 200, "with tokio runtime");
-      // }
+        assertApproximateTime(time, 200, "with tokio runtime");
+      }
 
-      // // Test fallible function/method
-      // {
-      //   var time1 = measureTimeMillis(() -> {
-      //     try {
-      //       Futures.fallibleMe(false).get();
-      //       assert true;
-      //     } catch (Exception e) {
-      //       assert false; // should never be reached
-      //     }
-      //   });
+      // Test fallible function/method
+      {
+        var time1 = measureTimeMillis(() -> {
+          try {
+            Futures.fallibleMe(false).get();
+            assert true;
+          } catch (Exception e) {
+            assert false; // should never be reached
+          }
+        });
 
-      //   System.out.print(MessageFormat.format("fallible function (with result): {0}ms", time1));
-      //   assert time1 < 100;
-      //   System.out.println(" ... ok");
+        System.out.print(MessageFormat.format("fallible function (with result): {0}ms", time1));
+        assert time1 < 100;
+        System.out.println(" ... ok");
 
-      //   var time2 = measureTimeMillis(() -> {
-      //     try {
-      //       Futures.fallibleMe(true).get();
-      //       assert false; // should never be reached
-      //     } catch (Exception e) {
-      //       assert true;
-      //     }
-      //   });
+        var time2 = measureTimeMillis(() -> {
+          try {
+            Futures.fallibleMe(true).get();
+            assert false; // should never be reached
+          } catch (Exception e) {
+            assert true;
+          }
+        });
 
-      //   System.out.print(MessageFormat.format("fallible function (with exception): {0}ms", time2));
-      //   assert time2 < 100;
-      //   System.out.println(" ... ok");
+        System.out.print(MessageFormat.format("fallible function (with exception): {0}ms", time2));
+        assert time2 < 100;
+        System.out.println(" ... ok");
 
-      //   var megaphone = Futures.newMegaphone();
+        var megaphone = Futures.newMegaphone();
 
-      //   var time3 = measureTimeMillis(() -> {
-      //     try {
-      //       megaphone.fallibleMe(false).get();
-      //       assert true;
-      //     } catch (Exception e) {
-      //       assert false; // should never be reached
-      //     }
-      //   });
+        var time3 = measureTimeMillis(() -> {
+          try {
+            megaphone.fallibleMe(false).get();
+            assert true;
+          } catch (Exception e) {
+            assert false; // should never be reached
+          }
+        });
 
-      //   System.out.print(MessageFormat.format("fallible method (with result): {0}ms", time3));
-      //   assert time3 < 100;
-      //   System.out.println(" ... ok");
+        System.out.print(MessageFormat.format("fallible method (with result): {0}ms", time3));
+        assert time3 < 100;
+        System.out.println(" ... ok");
         
-      //   var time4 = measureTimeMillis(() -> {
-      //     try {
-      //       megaphone.fallibleMe(true).get();
-      //       assert false; // should never be reached
-      //     } catch (Exception e) {
-      //       assert true;
-      //     }
-      //   });
+        var time4 = measureTimeMillis(() -> {
+          try {
+            megaphone.fallibleMe(true).get();
+            assert false; // should never be reached
+          } catch (Exception e) {
+            assert true;
+          }
+        });
 
-      //   System.out.print(MessageFormat.format("fallible method (with exception): {0}ms", time4));
-      //   assert time4 < 100;
-      //   System.out.println(" ... ok");
+        System.out.print(MessageFormat.format("fallible method (with exception): {0}ms", time4));
+        assert time4 < 100;
+        System.out.println(" ... ok");
 
-      //   Futures.fallibleStruct(false).get();
-      //   try {
-      //     Futures.fallibleStruct(true).get();
-      //     assert false; // should never be reached
-      //   } catch (Exception e) {
-      //     assert true;
-      //   }
-      // }
+        Futures.fallibleStruct(false).get();
+        try {
+          Futures.fallibleStruct(true).get();
+          assert false; // should never be reached
+        } catch (Exception e) {
+          assert true;
+        }
+      }
 
-      // // Test record.
-      // {
-      //   var time = measureTimeMillis(() -> {
-      //     var result = Futures.newMyRecord("foo", 42).get();
+      // Test record.
+      {
+        var time = measureTimeMillis(() -> {
+          var result = Futures.newMyRecord("foo", 42).get();
 
-      //     assert result.a().equals("foo");
-      //     assert result.b() == 42;
-      //   });
+          assert result.a().equals("foo");
+          assert result.b() == 42;
+        });
 
-      //   System.out.print(MessageFormat.format("record: {0}ms", time));
-      //   assert time < 100;
-      //   System.out.println(" ... ok");
-      // }
+        System.out.print(MessageFormat.format("record: {0}ms", time));
+        assert time < 100;
+        System.out.println(" ... ok");
+      }
 
-      // // Test a broken sleep.
-      // {
-      //   var time = measureTimeMillis(() -> {
-      //     Futures.brokenSleep((short)100, (short)0).get(); // calls the waker twice immediately
-      //     Futures.sleep((short)100).get(); // wait for possible failure
+      // Test a broken sleep.
+      {
+        var time = measureTimeMillis(() -> {
+          Futures.brokenSleep((short)100, (short)0).get(); // calls the waker twice immediately
+          Futures.sleep((short)100).get(); // wait for possible failure
 
-      //     Futures.brokenSleep((short)100, (short)100).get(); // calls the waker a second time after 1s
-      //     Futures.sleep((short)200).get(); // wait for possible failure
-      //   });
+          Futures.brokenSleep((short)100, (short)100).get(); // calls the waker a second time after 1s
+          Futures.sleep((short)200).get(); // wait for possible failure
+        });
 
-      //   assertApproximateTime(time, 500, "broken sleep");
-      // }
+        assertApproximateTime(time, 500, "broken sleep");
+      }
 
-      // // Test a future that uses a lock and that is cancelled.
-      // {
-      //   var time = measureTimeMillis(() -> {
-      //     var job = Futures.useSharedResource(new SharedResourceOptions((short)5000, (short)100));
+      // Test a future that uses a lock and that is cancelled.
+      {
+        var time = measureTimeMillis(() -> {
+          var job = Futures.useSharedResource(new SharedResourceOptions((short)5000, (short)100));
 
-      //     // Wait some time to ensure the task has locked the shared resource
-      //     TestFixtureFutures.delay(50).get();
-      //     // Cancel the job before the shared resource has been released.
-      //     job.cancel(true);
+          // Wait some time to ensure the task has locked the shared resource
+          TestFixtureFutures.delay(50).get();
+          // Cancel the job before the shared resource has been released.
+          job.cancel(true);
 
-      //     // Try accessing the shared resource again. The initial task should release the shared resource before the
-      //     // timeout expires.
-      //     Futures.useSharedResource(new SharedResourceOptions((short)0, (short)1000)).get();
-      //   });
+          // Try accessing the shared resource again. The initial task should release the shared resource before the
+          // timeout expires.
+          Futures.useSharedResource(new SharedResourceOptions((short)0, (short)1000)).get();
+        });
 
-      //   System.out.println(MessageFormat.format("useSharedResource: {0}ms", time));
-      // }
+        System.out.println(MessageFormat.format("useSharedResource: {0}ms", time));
+      }
 
-      // // Test a future that uses a lock and that is not cancelled.
-      // {
-      //   var time = measureTimeMillis(() -> {
-      //     // spawn both at the same time so they contend for the resource
-      //     var f1 = Futures.useSharedResource(new SharedResourceOptions((short)100, (short)1000));
-      //     var f2 = Futures.useSharedResource(new SharedResourceOptions((short)0, (short)1000));
+      // Test a future that uses a lock and that is not cancelled.
+      {
+        var time = measureTimeMillis(() -> {
+          // spawn both at the same time so they contend for the resource
+          var f1 = Futures.useSharedResource(new SharedResourceOptions((short)100, (short)1000));
+          var f2 = Futures.useSharedResource(new SharedResourceOptions((short)0, (short)1000));
 
-      //     f1.get();
-      //     f2.get();
-      //   });
+          f1.get();
+          f2.get();
+        });
 
-      //   System.out.println(MessageFormat.format("useSharedResource (not cancelled): {0}ms", time));
-      // }
+        System.out.println(MessageFormat.format("useSharedResource (not cancelled): {0}ms", time));
+      }
     } finally {
       // bring down the scheduler, if it's not shut down it'll hold the main thread open.
       scheduler.shutdown();

--- a/tests/scripts/TestFixtureFutures/TestFixtureFutures.java
+++ b/tests/scripts/TestFixtureFutures/TestFixtureFutures.java
@@ -192,7 +192,6 @@ public class TestFixtureFutures {
 
           @Override
           public CompletableFuture<Integer> tryFromString(Integer delayMs, String value) {
-            System.out.println("In trait function " + System.currentTimeMillis());
             return TestFixtureFutures.delay((long)delayMs).thenCompose((Void nothing) -> {
               CompletableFuture<Integer> f = new CompletableFuture<>();
               if (value.equals("force-unexpected-exception")) {
@@ -200,10 +199,8 @@ public class TestFixtureFutures {
                 return f;
               }
               try {
-                System.out.println("trying int parse in trait " + System.currentTimeMillis());
                 f.complete(Integer.parseInt(value));
               } catch (NumberFormatException e) {
-                System.out.println("excepted int parse in trait " + System.currentTimeMillis());
                 f.completeExceptionally(new ParserException.NotAnInt());
               }
               return f;
@@ -275,7 +272,6 @@ public class TestFixtureFutures {
 
         // Test that all handles were cleaned up
         var endingHandleCount = UniffiAsyncHelpers.uniffiForeignFutureHandleCount();
-        System.out.println("got handle count " + System.currentTimeMillis());
         assert endingHandleCount == 0 : MessageFormat.format("{0} current handle count != 0", endingHandleCount);
       }
 

--- a/tests/scripts/TestFixtureFutures/TestFixtureFutures.java
+++ b/tests/scripts/TestFixtureFutures/TestFixtureFutures.java
@@ -230,8 +230,8 @@ public class TestFixtureFutures {
         }
 
         var traitObj = new JavaAsyncParser();
-        // assert Futures.asStringUsingTrait(traitObj, 1, 42).get().equals("42");
-        // assert Futures.tryFromStringUsingTrait(traitObj, 1, "42").get().equals(42);
+        assert Futures.asStringUsingTrait(traitObj, 1, 42).get().equals("42");
+        assert Futures.tryFromStringUsingTrait(traitObj, 1, "42").get().equals(42);
         // try {
         //   Futures.tryFromStringUsingTrait(traitObj, 1, "fourty-two").get();
         //   throw new RuntimeException("Expected last statement to throw");
@@ -242,19 +242,19 @@ public class TestFixtureFutures {
         //     throw e;
         //   }
         // }
-        System.out.println("trying exception future " + System.currentTimeMillis());
-        try {
-          Futures.tryFromStringUsingTrait(traitObj, 1, "force-unexpected-exception").get();
-          throw new RuntimeException("Expected last statement to throw");
-        } catch (ExecutionException e) {
-          if (e.getCause() instanceof ParserException.UnexpectedException) {
-             // Expected
-          } else {
-             throw e;
-          }
-        }
-        System.out.println("finished exception future " + System.currentTimeMillis());
-        // Futures.delayUsingTrait(traitObj, 1).get();
+        // System.out.println("trying exception future " + System.currentTimeMillis());
+        // try {
+        //   Futures.tryFromStringUsingTrait(traitObj, 1, "force-unexpected-exception").get();
+        //   throw new RuntimeException("Expected last statement to throw");
+        // } catch (ExecutionException e) {
+        //   if (e.getCause() instanceof ParserException.UnexpectedException) {
+        //      // Expected
+        //   } else {
+        //      throw e;
+        //   }
+        // }
+        // System.out.println("finished exception future " + System.currentTimeMillis());
+        Futures.delayUsingTrait(traitObj, 1).get();
         // try {
         //   Futures.tryDelayUsingTrait(traitObj, "one").get();
         //   throw new RuntimeException("Expected last statement to throw");
@@ -265,12 +265,12 @@ public class TestFixtureFutures {
         //     throw e;
         //   }
         // }
-        // var completedDelaysBefore = traitObj.completedDelays;
-        // Futures.cancelDelayUsingTrait(traitObj, 50).get();
-        // // sleep long enough so that the `delay()` call would finish if it wasn't cancelled.
-        // TestFixtureFutures.delay(200).get();
-        // // If the task was cancelled, then completedDelays won't have increased
-        // assert traitObj.completedDelays == completedDelaysBefore : MessageFormat.format("{0} current delays != {1} delays before", traitObj.completedDelays, completedDelaysBefore);
+        var completedDelaysBefore = traitObj.completedDelays;
+        Futures.cancelDelayUsingTrait(traitObj, 50).get();
+        // sleep long enough so that the `delay()` call would finish if it wasn't cancelled.
+        TestFixtureFutures.delay(200).get();
+        // If the task was cancelled, then completedDelays won't have increased
+        assert traitObj.completedDelays == completedDelaysBefore : MessageFormat.format("{0} current delays != {1} delays before", traitObj.completedDelays, completedDelaysBefore);
 
         // Test that all handles were cleaned up
         System.gc();

--- a/tests/scripts/TestFixtureFutures/TestFixtureFutures.java
+++ b/tests/scripts/TestFixtureFutures/TestFixtureFutures.java
@@ -242,6 +242,7 @@ public class TestFixtureFutures {
         //     throw e;
         //   }
         // }
+        System.out.println("trying exception future " + System.currentTimeMillis());
         try {
           Futures.tryFromStringUsingTrait(traitObj, 1, "force-unexpected-exception").get();
           throw new RuntimeException("Expected last statement to throw");
@@ -252,6 +253,7 @@ public class TestFixtureFutures {
              throw e;
           }
         }
+        System.out.println("finished exception future " + System.currentTimeMillis());
         // Futures.delayUsingTrait(traitObj, 1).get();
         // try {
         //   Futures.tryDelayUsingTrait(traitObj, "one").get();
@@ -273,6 +275,7 @@ public class TestFixtureFutures {
         // Test that all handles were cleaned up
         System.gc();
         var endingHandleCount = UniffiAsyncHelpers.uniffiForeignFutureHandleCount();
+        System.out.println("got handle count " + System.currentTimeMillis());
         assert endingHandleCount == 0 : MessageFormat.format("{0} current handle count != 0", endingHandleCount);
       }
 

--- a/tests/scripts/TestFixtureFutures/TestFixtureFutures.java
+++ b/tests/scripts/TestFixtureFutures/TestFixtureFutures.java
@@ -242,27 +242,27 @@ public class TestFixtureFutures {
         //     throw e;
         //   }
         // }
-        // try {
-        //   Futures.tryFromStringUsingTrait(traitObj, 1, "force-unexpected-exception").get();
-        //   throw new RuntimeException("Expected last statement to throw");
-        // } catch (ExecutionException e) {
-        //   if (e.getCause() instanceof ParserException.UnexpectedException) {
-        //      // Expected
-        //   } else {
-        //      throw e;
-        //   }
-        // }
-        Futures.delayUsingTrait(traitObj, 1).get();
         try {
-          Futures.tryDelayUsingTrait(traitObj, "one").get();
+          Futures.tryFromStringUsingTrait(traitObj, 1, "force-unexpected-exception").get();
           throw new RuntimeException("Expected last statement to throw");
         } catch (ExecutionException e) {
-          if (e.getCause() instanceof ParserException.NotAnInt) {
-            // Expected
+          if (e.getCause() instanceof ParserException.UnexpectedException) {
+             // Expected
           } else {
-            throw e;
+             throw e;
           }
         }
+        // Futures.delayUsingTrait(traitObj, 1).get();
+        // try {
+        //   Futures.tryDelayUsingTrait(traitObj, "one").get();
+        //   throw new RuntimeException("Expected last statement to throw");
+        // } catch (ExecutionException e) {
+        //   if (e.getCause() instanceof ParserException.NotAnInt) {
+        //     // Expected
+        //   } else {
+        //     throw e;
+        //   }
+        // }
         // var completedDelaysBefore = traitObj.completedDelays;
         // Futures.cancelDelayUsingTrait(traitObj, 50).get();
         // // sleep long enough so that the `delay()` call would finish if it wasn't cancelled.

--- a/tests/scripts/TestFixtureFutures/TestFixtureFutures.java
+++ b/tests/scripts/TestFixtureFutures/TestFixtureFutures.java
@@ -47,136 +47,136 @@ public class TestFixtureFutures {
 
   public static void main(String[] args) throws Exception {
     try {
-      // init UniFFI to get good measurements after that
-      {
-        var time = measureTimeMillis(() -> {
-            Futures.alwaysReady().get();
-        });
+      // // init UniFFI to get good measurements after that
+      // {
+      //   var time = measureTimeMillis(() -> {
+      //       Futures.alwaysReady().get();
+      //   });
 
-        System.out.println(MessageFormat.format("init time: {0}ms", time));
-      }
+      //   System.out.println(MessageFormat.format("init time: {0}ms", time));
+      // }
 
-      // Test `always_ready`
-      {
-        var time = measureTimeMillis(() -> {
-            var result = Futures.alwaysReady().get();
-            assert result.equals(true);
-        });
+      // // Test `always_ready`
+      // {
+      //   var time = measureTimeMillis(() -> {
+      //       var result = Futures.alwaysReady().get();
+      //       assert result.equals(true);
+      //   });
 
-        assertReturnsImmediately(time, "always_ready");
-      }
+      //   assertReturnsImmediately(time, "always_ready");
+      // }
 
-      // Test `void`.
-      {
-        var time = measureTimeMillis(() -> {
-          var result = Futures._void().get();
+      // // Test `void`.
+      // {
+      //   var time = measureTimeMillis(() -> {
+      //     var result = Futures._void().get();
 
-          assert result == null;
-        });
+      //     assert result == null;
+      //   });
 
-        assertReturnsImmediately(time, "void");
-      }
+      //   assertReturnsImmediately(time, "void");
+      // }
 
-      // Test `sleep`.
-      {
-        var time = measureTimeMillis(() -> {
-          Futures.sleep((short)200).get();
-        });
+      // // Test `sleep`.
+      // {
+      //   var time = measureTimeMillis(() -> {
+      //     Futures.sleep((short)200).get();
+      //   });
 
-        assertApproximateTime(time, 200, "sleep");
-      }
+      //   assertApproximateTime(time, 200, "sleep");
+      // }
     
-      // Test sequential futures.
-      {
-        var time = measureTimeMillis(() -> {
-          var aliceResult = Futures.sayAfter((short)100, "Alice").get();
-          var bobResult = Futures.sayAfter((short)200, "Bob").get();
+      // // Test sequential futures.
+      // {
+      //   var time = measureTimeMillis(() -> {
+      //     var aliceResult = Futures.sayAfter((short)100, "Alice").get();
+      //     var bobResult = Futures.sayAfter((short)200, "Bob").get();
 
-          assert aliceResult.equals("Hello, Alice!");
-          assert bobResult.equals("Hello, Bob!");
-        });
+      //     assert aliceResult.equals("Hello, Alice!");
+      //     assert bobResult.equals("Hello, Bob!");
+      //   });
 
-        assertApproximateTime(time, 300, "sequential future");
-      }
+      //   assertApproximateTime(time, 300, "sequential future");
+      // }
 
-      // Test concurrent futures.
-      {
-        var time = measureTimeMillis(() -> {
-          var alice = Futures.sayAfter((short)100, "Alice");
-          var bob = Futures.sayAfter((short)200, "Bob");
+      // // Test concurrent futures.
+      // {
+      //   var time = measureTimeMillis(() -> {
+      //     var alice = Futures.sayAfter((short)100, "Alice");
+      //     var bob = Futures.sayAfter((short)200, "Bob");
 
-          assert alice.get().equals("Hello, Alice!");
-          assert bob.get().equals("Hello, Bob!");
-        });
+      //     assert alice.get().equals("Hello, Alice!");
+      //     assert bob.get().equals("Hello, Bob!");
+      //   });
     
-        assertApproximateTime(time, 200, "concurrent future");
-      }
+      //   assertApproximateTime(time, 200, "concurrent future");
+      // }
 
-      // Test async methods.
-      {
-        var megaphone = Futures.newMegaphone();
-        var time = measureTimeMillis(() -> {
-          var resultAlice = megaphone.sayAfter((short)200, "Alice").get();
+      // // Test async methods.
+      // {
+      //   var megaphone = Futures.newMegaphone();
+      //   var time = measureTimeMillis(() -> {
+      //     var resultAlice = megaphone.sayAfter((short)200, "Alice").get();
 
-          assert resultAlice.equals("HELLO, ALICE!");
-        });
+      //     assert resultAlice.equals("HELLO, ALICE!");
+      //   });
 
-        assertApproximateTime(time, 200, "async methods");
-      }
+      //   assertApproximateTime(time, 200, "async methods");
+      // }
 
-      {
-        var megaphone = Futures.newMegaphone();
-        var time = measureTimeMillis(() -> {
-          var resultAlice = Futures.sayAfterWithMegaphone(megaphone, (short)200, "Alice").get();
+      // {
+      //   var megaphone = Futures.newMegaphone();
+      //   var time = measureTimeMillis(() -> {
+      //     var resultAlice = Futures.sayAfterWithMegaphone(megaphone, (short)200, "Alice").get();
 
-          assert resultAlice.equals("HELLO, ALICE!");
-        });
+      //     assert resultAlice.equals("HELLO, ALICE!");
+      //   });
 
-        assertApproximateTime(time, 200, "async methods");
-      }
+      //   assertApproximateTime(time, 200, "async methods");
+      // }
 
-      // Test async constructors
-      {
-        var megaphone = Megaphone.secondary().get();
-        assert megaphone.sayAfter((short)1, "hi").get().equals("HELLO, HI!");
-      }
+      // // Test async constructors
+      // {
+      //   var megaphone = Megaphone.secondary().get();
+      //   assert megaphone.sayAfter((short)1, "hi").get().equals("HELLO, HI!");
+      // }
 
-      // Test async method returning optional object
-      {
-        var megaphone = Futures.asyncMaybeNewMegaphone(true).get();
-        assert megaphone != null;
+      // // Test async method returning optional object
+      // {
+      //   var megaphone = Futures.asyncMaybeNewMegaphone(true).get();
+      //   assert megaphone != null;
     
-        var not_megaphone = Futures.asyncMaybeNewMegaphone(false).get();
-        assert not_megaphone == null;
-      }
+      //   var not_megaphone = Futures.asyncMaybeNewMegaphone(false).get();
+      //   assert not_megaphone == null;
+      // }
 
-      // Test async methods in trait interfaces
-      {
-        var traits = Futures.getSayAfterTraits();
-        var time = measureTimeMillis(() -> {
-          var result1 = traits.get(0).sayAfter((short)100, "Alice").get();
-          var result2 = traits.get(1).sayAfter((short)100, "Bob").get();
+      // // Test async methods in trait interfaces
+      // {
+      //   var traits = Futures.getSayAfterTraits();
+      //   var time = measureTimeMillis(() -> {
+      //     var result1 = traits.get(0).sayAfter((short)100, "Alice").get();
+      //     var result2 = traits.get(1).sayAfter((short)100, "Bob").get();
 
-          assert result1.equals("Hello, Alice!");
-          assert result2.equals("Hello, Bob!");
-        });
+      //     assert result1.equals("Hello, Alice!");
+      //     assert result2.equals("Hello, Bob!");
+      //   });
 
-        assertApproximateTime(time, 200, "async trait methods");
-      }
+      //   assertApproximateTime(time, 200, "async trait methods");
+      // }
 
-      // Test async methods in UDL-defined trait interfaces
-      {
-        var traits = Futures.getSayAfterUdlTraits();
-        var time = measureTimeMillis(() -> {
-          var result1 = traits.get(0).sayAfter((short)100, "Alice").get();
-          var result2 = traits.get(1).sayAfter((short)100, "Bob").get();
+      // // Test async methods in UDL-defined trait interfaces
+      // {
+      //   var traits = Futures.getSayAfterUdlTraits();
+      //   var time = measureTimeMillis(() -> {
+      //     var result1 = traits.get(0).sayAfter((short)100, "Alice").get();
+      //     var result2 = traits.get(1).sayAfter((short)100, "Bob").get();
 
-          assert result1.equals("Hello, Alice!");
-          assert result2.equals("Hello, Bob!");
-        });
+      //     assert result1.equals("Hello, Alice!");
+      //     assert result2.equals("Hello, Bob!");
+      //   });
 
-        assertApproximateTime(time, 200, "async UDL methods");
-      }
+      //   assertApproximateTime(time, 200, "async UDL methods");
+      // }
 
       // Test foreign implemented async trait methods
       {
@@ -192,6 +192,7 @@ public class TestFixtureFutures {
 
           @Override
           public CompletableFuture<Integer> tryFromString(Integer delayMs, String value) {
+            System.out.println("In trait function " + System.currentTimeMillis());
             return TestFixtureFutures.delay((long)delayMs).thenCompose((Void nothing) -> {
               CompletableFuture<Integer> f = new CompletableFuture<>();
               if (value.equals("force-unexpected-exception")) {
@@ -199,8 +200,10 @@ public class TestFixtureFutures {
                 return f;
               }
               try {
+                System.out.println("trying int parse in trait " + System.currentTimeMillis());
                 f.complete(Integer.parseInt(value));
               } catch (NumberFormatException e) {
+                System.out.println("excepted int parse in trait " + System.currentTimeMillis());
                 f.completeExceptionally(new ParserException.NotAnInt());
               }
               return f;
@@ -230,8 +233,10 @@ public class TestFixtureFutures {
         }
 
         var traitObj = new JavaAsyncParser();
-        assert Futures.asStringUsingTrait(traitObj, 1, 42).get().equals("42");
+        // assert Futures.asStringUsingTrait(traitObj, 1, 42).get().equals("42");
+        System.out.println("java test calling for trait method " + System.currentTimeMillis());
         assert Futures.tryFromStringUsingTrait(traitObj, 1, "42").get().equals(42);
+        System.out.println("java test finished trait method " + System.currentTimeMillis());
         // try {
         //   Futures.tryFromStringUsingTrait(traitObj, 1, "fourty-two").get();
         //   throw new RuntimeException("Expected last statement to throw");
@@ -242,7 +247,6 @@ public class TestFixtureFutures {
         //     throw e;
         //   }
         // }
-        // System.out.println("trying exception future " + System.currentTimeMillis());
         // try {
         //   Futures.tryFromStringUsingTrait(traitObj, 1, "force-unexpected-exception").get();
         //   throw new RuntimeException("Expected last statement to throw");
@@ -253,8 +257,7 @@ public class TestFixtureFutures {
         //      throw e;
         //   }
         // }
-        // System.out.println("finished exception future " + System.currentTimeMillis());
-        Futures.delayUsingTrait(traitObj, 1).get();
+        // Futures.delayUsingTrait(traitObj, 1).get();
         // try {
         //   Futures.tryDelayUsingTrait(traitObj, "one").get();
         //   throw new RuntimeException("Expected last statement to throw");
@@ -265,12 +268,12 @@ public class TestFixtureFutures {
         //     throw e;
         //   }
         // }
-        var completedDelaysBefore = traitObj.completedDelays;
-        Futures.cancelDelayUsingTrait(traitObj, 50).get();
-        // sleep long enough so that the `delay()` call would finish if it wasn't cancelled.
-        TestFixtureFutures.delay(200).get();
-        // If the task was cancelled, then completedDelays won't have increased
-        assert traitObj.completedDelays == completedDelaysBefore : MessageFormat.format("{0} current delays != {1} delays before", traitObj.completedDelays, completedDelaysBefore);
+        // var completedDelaysBefore = traitObj.completedDelays;
+        // Futures.cancelDelayUsingTrait(traitObj, 50).get();
+        // // sleep long enough so that the `delay()` call would finish if it wasn't cancelled.
+        // TestFixtureFutures.delay(200).get();
+        // // If the task was cancelled, then completedDelays won't have increased
+        // assert traitObj.completedDelays == completedDelaysBefore : MessageFormat.format("{0} current delays != {1} delays before", traitObj.completedDelays, completedDelaysBefore);
 
         // Test that all handles were cleaned up
         System.gc();
@@ -279,140 +282,140 @@ public class TestFixtureFutures {
         assert endingHandleCount == 0 : MessageFormat.format("{0} current handle count != 0", endingHandleCount);
       }
 
-      // Test with the Tokio runtime.
-      {
-        var time = measureTimeMillis(() -> {
-          var resultAlice = Futures.sayAfterWithTokio((short)200, "Alice").get();
+      // // Test with the Tokio runtime.
+      // {
+      //   var time = measureTimeMillis(() -> {
+      //     var resultAlice = Futures.sayAfterWithTokio((short)200, "Alice").get();
 
-          assert resultAlice.equals("Hello, Alice (with Tokio)!");
-        });
+      //     assert resultAlice.equals("Hello, Alice (with Tokio)!");
+      //   });
 
-        assertApproximateTime(time, 200, "with tokio runtime");
-      }
+      //   assertApproximateTime(time, 200, "with tokio runtime");
+      // }
 
-      // Test fallible function/method
-      {
-        var time1 = measureTimeMillis(() -> {
-          try {
-            Futures.fallibleMe(false).get();
-            assert true;
-          } catch (Exception e) {
-            assert false; // should never be reached
-          }
-        });
+      // // Test fallible function/method
+      // {
+      //   var time1 = measureTimeMillis(() -> {
+      //     try {
+      //       Futures.fallibleMe(false).get();
+      //       assert true;
+      //     } catch (Exception e) {
+      //       assert false; // should never be reached
+      //     }
+      //   });
 
-        System.out.print(MessageFormat.format("fallible function (with result): {0}ms", time1));
-        assert time1 < 100;
-        System.out.println(" ... ok");
+      //   System.out.print(MessageFormat.format("fallible function (with result): {0}ms", time1));
+      //   assert time1 < 100;
+      //   System.out.println(" ... ok");
 
-        var time2 = measureTimeMillis(() -> {
-          try {
-            Futures.fallibleMe(true).get();
-            assert false; // should never be reached
-          } catch (Exception e) {
-            assert true;
-          }
-        });
+      //   var time2 = measureTimeMillis(() -> {
+      //     try {
+      //       Futures.fallibleMe(true).get();
+      //       assert false; // should never be reached
+      //     } catch (Exception e) {
+      //       assert true;
+      //     }
+      //   });
 
-        System.out.print(MessageFormat.format("fallible function (with exception): {0}ms", time2));
-        assert time2 < 100;
-        System.out.println(" ... ok");
+      //   System.out.print(MessageFormat.format("fallible function (with exception): {0}ms", time2));
+      //   assert time2 < 100;
+      //   System.out.println(" ... ok");
 
-        var megaphone = Futures.newMegaphone();
+      //   var megaphone = Futures.newMegaphone();
 
-        var time3 = measureTimeMillis(() -> {
-          try {
-            megaphone.fallibleMe(false).get();
-            assert true;
-          } catch (Exception e) {
-            assert false; // should never be reached
-          }
-        });
+      //   var time3 = measureTimeMillis(() -> {
+      //     try {
+      //       megaphone.fallibleMe(false).get();
+      //       assert true;
+      //     } catch (Exception e) {
+      //       assert false; // should never be reached
+      //     }
+      //   });
 
-        System.out.print(MessageFormat.format("fallible method (with result): {0}ms", time3));
-        assert time3 < 100;
-        System.out.println(" ... ok");
+      //   System.out.print(MessageFormat.format("fallible method (with result): {0}ms", time3));
+      //   assert time3 < 100;
+      //   System.out.println(" ... ok");
         
-        var time4 = measureTimeMillis(() -> {
-          try {
-            megaphone.fallibleMe(true).get();
-            assert false; // should never be reached
-          } catch (Exception e) {
-            assert true;
-          }
-        });
+      //   var time4 = measureTimeMillis(() -> {
+      //     try {
+      //       megaphone.fallibleMe(true).get();
+      //       assert false; // should never be reached
+      //     } catch (Exception e) {
+      //       assert true;
+      //     }
+      //   });
 
-        System.out.print(MessageFormat.format("fallible method (with exception): {0}ms", time4));
-        assert time4 < 100;
-        System.out.println(" ... ok");
+      //   System.out.print(MessageFormat.format("fallible method (with exception): {0}ms", time4));
+      //   assert time4 < 100;
+      //   System.out.println(" ... ok");
 
-        Futures.fallibleStruct(false).get();
-        try {
-          Futures.fallibleStruct(true).get();
-          assert false; // should never be reached
-        } catch (Exception e) {
-          assert true;
-        }
-      }
+      //   Futures.fallibleStruct(false).get();
+      //   try {
+      //     Futures.fallibleStruct(true).get();
+      //     assert false; // should never be reached
+      //   } catch (Exception e) {
+      //     assert true;
+      //   }
+      // }
 
-      // Test record.
-      {
-        var time = measureTimeMillis(() -> {
-          var result = Futures.newMyRecord("foo", 42).get();
+      // // Test record.
+      // {
+      //   var time = measureTimeMillis(() -> {
+      //     var result = Futures.newMyRecord("foo", 42).get();
 
-          assert result.a().equals("foo");
-          assert result.b() == 42;
-        });
+      //     assert result.a().equals("foo");
+      //     assert result.b() == 42;
+      //   });
 
-        System.out.print(MessageFormat.format("record: {0}ms", time));
-        assert time < 100;
-        System.out.println(" ... ok");
-      }
+      //   System.out.print(MessageFormat.format("record: {0}ms", time));
+      //   assert time < 100;
+      //   System.out.println(" ... ok");
+      // }
 
-      // Test a broken sleep.
-      {
-        var time = measureTimeMillis(() -> {
-          Futures.brokenSleep((short)100, (short)0).get(); // calls the waker twice immediately
-          Futures.sleep((short)100).get(); // wait for possible failure
+      // // Test a broken sleep.
+      // {
+      //   var time = measureTimeMillis(() -> {
+      //     Futures.brokenSleep((short)100, (short)0).get(); // calls the waker twice immediately
+      //     Futures.sleep((short)100).get(); // wait for possible failure
 
-          Futures.brokenSleep((short)100, (short)100).get(); // calls the waker a second time after 1s
-          Futures.sleep((short)200).get(); // wait for possible failure
-        });
+      //     Futures.brokenSleep((short)100, (short)100).get(); // calls the waker a second time after 1s
+      //     Futures.sleep((short)200).get(); // wait for possible failure
+      //   });
 
-        assertApproximateTime(time, 500, "broken sleep");
-      }
+      //   assertApproximateTime(time, 500, "broken sleep");
+      // }
 
-      // Test a future that uses a lock and that is cancelled.
-      {
-        var time = measureTimeMillis(() -> {
-          var job = Futures.useSharedResource(new SharedResourceOptions((short)5000, (short)100));
+      // // Test a future that uses a lock and that is cancelled.
+      // {
+      //   var time = measureTimeMillis(() -> {
+      //     var job = Futures.useSharedResource(new SharedResourceOptions((short)5000, (short)100));
 
-          // Wait some time to ensure the task has locked the shared resource
-          TestFixtureFutures.delay(50).get();
-          // Cancel the job before the shared resource has been released.
-          job.cancel(true);
+      //     // Wait some time to ensure the task has locked the shared resource
+      //     TestFixtureFutures.delay(50).get();
+      //     // Cancel the job before the shared resource has been released.
+      //     job.cancel(true);
 
-          // Try accessing the shared resource again. The initial task should release the shared resource before the
-          // timeout expires.
-          Futures.useSharedResource(new SharedResourceOptions((short)0, (short)1000)).get();
-        });
+      //     // Try accessing the shared resource again. The initial task should release the shared resource before the
+      //     // timeout expires.
+      //     Futures.useSharedResource(new SharedResourceOptions((short)0, (short)1000)).get();
+      //   });
 
-        System.out.println(MessageFormat.format("useSharedResource: {0}ms", time));
-      }
+      //   System.out.println(MessageFormat.format("useSharedResource: {0}ms", time));
+      // }
 
-      // Test a future that uses a lock and that is not cancelled.
-      {
-        var time = measureTimeMillis(() -> {
-          // spawn both at the same time so they contend for the resource
-          var f1 = Futures.useSharedResource(new SharedResourceOptions((short)100, (short)1000));
-          var f2 = Futures.useSharedResource(new SharedResourceOptions((short)0, (short)1000));
+      // // Test a future that uses a lock and that is not cancelled.
+      // {
+      //   var time = measureTimeMillis(() -> {
+      //     // spawn both at the same time so they contend for the resource
+      //     var f1 = Futures.useSharedResource(new SharedResourceOptions((short)100, (short)1000));
+      //     var f2 = Futures.useSharedResource(new SharedResourceOptions((short)0, (short)1000));
 
-          f1.get();
-          f2.get();
-        });
+      //     f1.get();
+      //     f2.get();
+      //   });
 
-        System.out.println(MessageFormat.format("useSharedResource (not cancelled): {0}ms", time));
-      }
+      //   System.out.println(MessageFormat.format("useSharedResource (not cancelled): {0}ms", time));
+      // }
     } finally {
       // bring down the scheduler, if it's not shut down it'll hold the main thread open.
       scheduler.shutdown();

--- a/tests/scripts/TestFixtureFutures/TestFixtureFutures.java
+++ b/tests/scripts/TestFixtureFutures/TestFixtureFutures.java
@@ -275,7 +275,6 @@ public class TestFixtureFutures {
         // wait until they're gone or we've timed out
         var emptyHandlesFuture = new CompletableFuture<>();
         final ScheduledFuture<?> checkHandles = scheduler.scheduleAtFixedRate(() -> {
-          System.out.println("Polling for all handles finished");
           if (UniffiAsyncHelpers.uniffiForeignFutureHandleCount() == 0) {
             emptyHandlesFuture.complete(null);
           }

--- a/tests/scripts/TestFixtureFutures/TestFixtureFutures.java
+++ b/tests/scripts/TestFixtureFutures/TestFixtureFutures.java
@@ -275,6 +275,7 @@ public class TestFixtureFutures {
         // wait until they're gone or we've timed out
         var emptyHandlesFuture = new CompletableFuture<>();
         final ScheduledFuture<?> checkHandles = scheduler.scheduleAtFixedRate(() -> {
+          System.out.println("Polling for all handles finished");
           if (UniffiAsyncHelpers.uniffiForeignFutureHandleCount() == 0) {
             emptyHandlesFuture.complete(null);
           }

--- a/tests/scripts/TestFixtureFutures/TestFixtureFutures.java
+++ b/tests/scripts/TestFixtureFutures/TestFixtureFutures.java
@@ -217,14 +217,14 @@ public class TestFixtureFutures {
 
           @Override
           public CompletableFuture<Void> tryDelay(String delayMs) {
-            System.out.println("java trait method executing" + System.currentTimeMillis());
+            System.out.println("java trait method executing " + System.currentTimeMillis());
             try {
               var parsed = Long.parseLong(delayMs);
               return TestFixtureFutures.delay(parsed).thenRun(() -> {
                 completedDelays += 1;
               });
             } catch (NumberFormatException e) {
-              System.out.println("java trait method caught exception" + System.currentTimeMillis());
+              System.out.println("java trait method caught exception " + System.currentTimeMillis());
               var f = new CompletableFuture<Void>();
               f.completeExceptionally(new ParserException.NotAnInt());
               return f;
@@ -269,7 +269,7 @@ public class TestFixtureFutures {
             throw e;
           }
         }
-        System.out.println("finished trait method from java test" + System.currentTimeMillis());
+        System.out.println("finished trait method from java test " + System.currentTimeMillis());
         // var completedDelaysBefore = traitObj.completedDelays;
         // Futures.cancelDelayUsingTrait(traitObj, 50).get();
         // // sleep long enough so that the `delay()` call would finish if it wasn't cancelled.

--- a/tests/scripts/TestFixtureFutures/TestFixtureFutures.java
+++ b/tests/scripts/TestFixtureFutures/TestFixtureFutures.java
@@ -220,14 +220,12 @@ public class TestFixtureFutures {
 
           @Override
           public CompletableFuture<Void> tryDelay(String delayMs) {
-            System.out.println("java trait method executing " + System.currentTimeMillis());
             try {
               var parsed = Long.parseLong(delayMs);
               return TestFixtureFutures.delay(parsed).thenRun(() -> {
                 completedDelays += 1;
               });
             } catch (NumberFormatException e) {
-              System.out.println("java trait method caught exception " + System.currentTimeMillis());
               var f = new CompletableFuture<Void>();
               f.completeExceptionally(new ParserException.NotAnInt());
               return f;
@@ -238,30 +236,29 @@ public class TestFixtureFutures {
         var traitObj = new JavaAsyncParser();
         var startingHandleCount = UniffiAsyncHelpers.uniffiForeignFutureHandleCount();
         assert startingHandleCount == 0 : MessageFormat.format("{0} starting handle count != 0", startingHandleCount);
-        // assert Futures.asStringUsingTrait(traitObj, 1, 42).get().equals("42");
-        // assert Futures.tryFromStringUsingTrait(traitObj, 1, "42").get().equals(42);
-        // try {
-        //   Futures.tryFromStringUsingTrait(traitObj, 1, "fourty-two").get();
-        //   throw new RuntimeException("Expected last statement to throw");
-        // } catch (ExecutionException e) {
-        //   if (e.getCause() instanceof ParserException.NotAnInt) {
-        //       // Expected
-        //   } else {
-        //     throw e;
-        //   }
-        // }
-        // try {
-        //   Futures.tryFromStringUsingTrait(traitObj, 1, "force-unexpected-exception").get();
-        //   throw new RuntimeException("Expected last statement to throw");
-        // } catch (ExecutionException e) {
-        //   if (e.getCause() instanceof ParserException.UnexpectedException) {
-        //      // Expected
-        //   } else {
-        //      throw e;
-        //   }
-        // }
-        // Futures.delayUsingTrait(traitObj, 1).get();
-        System.out.println("calling for trait method from java test " + System.currentTimeMillis());
+        assert Futures.asStringUsingTrait(traitObj, 1, 42).get().equals("42");
+        assert Futures.tryFromStringUsingTrait(traitObj, 1, "42").get().equals(42);
+        try {
+          Futures.tryFromStringUsingTrait(traitObj, 1, "fourty-two").get();
+          throw new RuntimeException("Expected last statement to throw");
+        } catch (ExecutionException e) {
+          if (e.getCause() instanceof ParserException.NotAnInt) {
+              // Expected
+          } else {
+            throw e;
+          }
+        }
+        try {
+          Futures.tryFromStringUsingTrait(traitObj, 1, "force-unexpected-exception").get();
+          throw new RuntimeException("Expected last statement to throw");
+        } catch (ExecutionException e) {
+          if (e.getCause() instanceof ParserException.UnexpectedException) {
+             // Expected
+          } else {
+             throw e;
+          }
+        }
+        Futures.delayUsingTrait(traitObj, 1).get();
         try {
           Futures.tryDelayUsingTrait(traitObj, "one").get();
           throw new RuntimeException("Expected last statement to throw");
@@ -272,13 +269,12 @@ public class TestFixtureFutures {
             throw e;
           }
         }
-        System.out.println("finished trait method from java test " + System.currentTimeMillis());
-        // var completedDelaysBefore = traitObj.completedDelays;
-        // Futures.cancelDelayUsingTrait(traitObj, 50).get();
-        // // sleep long enough so that the `delay()` call would finish if it wasn't cancelled.
-        // TestFixtureFutures.delay(200).get();
-        // // If the task was cancelled, then completedDelays won't have increased
-        // assert traitObj.completedDelays == completedDelaysBefore : MessageFormat.format("{0} current delays != {1} delays before", traitObj.completedDelays, completedDelaysBefore);
+        var completedDelaysBefore = traitObj.completedDelays;
+        Futures.cancelDelayUsingTrait(traitObj, 50).get();
+        // sleep long enough so that the `delay()` call would finish if it wasn't cancelled.
+        TestFixtureFutures.delay(200).get();
+        // If the task was cancelled, then completedDelays won't have increased
+        assert traitObj.completedDelays == completedDelaysBefore : MessageFormat.format("{0} current delays != {1} delays before", traitObj.completedDelays, completedDelaysBefore);
 
         // Test that all handles were cleaned up
         var endingHandleCount = UniffiAsyncHelpers.uniffiForeignFutureHandleCount();

--- a/tests/scripts/TestFixtureFutures/TestFixtureFutures.java
+++ b/tests/scripts/TestFixtureFutures/TestFixtureFutures.java
@@ -252,7 +252,6 @@ public class TestFixtureFutures {
              throw e;
           }
         }
-        TestFixtureFutures.delay(5000).get();
         // Futures.delayUsingTrait(traitObj, 1).get();
         // try {
         //   Futures.tryDelayUsingTrait(traitObj, "one").get();

--- a/tests/scripts/TestFixtureFutures/TestFixtureFutures.java
+++ b/tests/scripts/TestFixtureFutures/TestFixtureFutures.java
@@ -5,7 +5,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
 public class TestFixtureFutures {

--- a/tests/scripts/TestFixtureFutures/TestFixtureFutures.java
+++ b/tests/scripts/TestFixtureFutures/TestFixtureFutures.java
@@ -57,127 +57,127 @@ public class TestFixtureFutures {
         System.out.println(MessageFormat.format("init time: {0}ms", time));
       }
 
-      // Test `always_ready`
-      {
-        var time = measureTimeMillis(() -> {
-            var result = Futures.alwaysReady().get();
-            assert result.equals(true);
-        });
+      // // Test `always_ready`
+      // {
+      //   var time = measureTimeMillis(() -> {
+      //       var result = Futures.alwaysReady().get();
+      //       assert result.equals(true);
+      //   });
 
-        assertReturnsImmediately(time, "always_ready");
-      }
+      //   assertReturnsImmediately(time, "always_ready");
+      // }
 
-      // Test `void`.
-      {
-        var time = measureTimeMillis(() -> {
-          var result = Futures._void().get();
+      // // Test `void`.
+      // {
+      //   var time = measureTimeMillis(() -> {
+      //     var result = Futures._void().get();
 
-          assert result == null;
-        });
+      //     assert result == null;
+      //   });
 
-        assertReturnsImmediately(time, "void");
-      }
+      //   assertReturnsImmediately(time, "void");
+      // }
 
-      // Test `sleep`.
-      {
-        var time = measureTimeMillis(() -> {
-          Futures.sleep((short)200).get();
-        });
+      // // Test `sleep`.
+      // {
+      //   var time = measureTimeMillis(() -> {
+      //     Futures.sleep((short)200).get();
+      //   });
 
-        assertApproximateTime(time, 200, "sleep");
-      }
+      //   assertApproximateTime(time, 200, "sleep");
+      // }
     
-      // Test sequential futures.
-      {
-        var time = measureTimeMillis(() -> {
-          var aliceResult = Futures.sayAfter((short)100, "Alice").get();
-          var bobResult = Futures.sayAfter((short)200, "Bob").get();
+      // // Test sequential futures.
+      // {
+      //   var time = measureTimeMillis(() -> {
+      //     var aliceResult = Futures.sayAfter((short)100, "Alice").get();
+      //     var bobResult = Futures.sayAfter((short)200, "Bob").get();
 
-          assert aliceResult.equals("Hello, Alice!");
-          assert bobResult.equals("Hello, Bob!");
-        });
+      //     assert aliceResult.equals("Hello, Alice!");
+      //     assert bobResult.equals("Hello, Bob!");
+      //   });
 
-        assertApproximateTime(time, 300, "sequential future");
-      }
+      //   assertApproximateTime(time, 300, "sequential future");
+      // }
 
-      // Test concurrent futures.
-      {
-        var time = measureTimeMillis(() -> {
-          var alice = Futures.sayAfter((short)100, "Alice");
-          var bob = Futures.sayAfter((short)200, "Bob");
+      // // Test concurrent futures.
+      // {
+      //   var time = measureTimeMillis(() -> {
+      //     var alice = Futures.sayAfter((short)100, "Alice");
+      //     var bob = Futures.sayAfter((short)200, "Bob");
 
-          assert alice.get().equals("Hello, Alice!");
-          assert bob.get().equals("Hello, Bob!");
-        });
+      //     assert alice.get().equals("Hello, Alice!");
+      //     assert bob.get().equals("Hello, Bob!");
+      //   });
     
-        assertApproximateTime(time, 200, "concurrent future");
-      }
+      //   assertApproximateTime(time, 200, "concurrent future");
+      // }
 
-      // Test async methods.
-      {
-        var megaphone = Futures.newMegaphone();
-        var time = measureTimeMillis(() -> {
-          var resultAlice = megaphone.sayAfter((short)200, "Alice").get();
+      // // Test async methods.
+      // {
+      //   var megaphone = Futures.newMegaphone();
+      //   var time = measureTimeMillis(() -> {
+      //     var resultAlice = megaphone.sayAfter((short)200, "Alice").get();
 
-          assert resultAlice.equals("HELLO, ALICE!");
-        });
+      //     assert resultAlice.equals("HELLO, ALICE!");
+      //   });
 
-        assertApproximateTime(time, 200, "async methods");
-      }
+      //   assertApproximateTime(time, 200, "async methods");
+      // }
 
-      {
-        var megaphone = Futures.newMegaphone();
-        var time = measureTimeMillis(() -> {
-          var resultAlice = Futures.sayAfterWithMegaphone(megaphone, (short)200, "Alice").get();
+      // {
+      //   var megaphone = Futures.newMegaphone();
+      //   var time = measureTimeMillis(() -> {
+      //     var resultAlice = Futures.sayAfterWithMegaphone(megaphone, (short)200, "Alice").get();
 
-          assert resultAlice.equals("HELLO, ALICE!");
-        });
+      //     assert resultAlice.equals("HELLO, ALICE!");
+      //   });
 
-        assertApproximateTime(time, 200, "async methods");
-      }
+      //   assertApproximateTime(time, 200, "async methods");
+      // }
 
-      // Test async constructors
-      {
-        var megaphone = Megaphone.secondary().get();
-        assert megaphone.sayAfter((short)1, "hi").get().equals("HELLO, HI!");
-      }
+      // // Test async constructors
+      // {
+      //   var megaphone = Megaphone.secondary().get();
+      //   assert megaphone.sayAfter((short)1, "hi").get().equals("HELLO, HI!");
+      // }
 
-      // Test async method returning optional object
-      {
-        var megaphone = Futures.asyncMaybeNewMegaphone(true).get();
-        assert megaphone != null;
+      // // Test async method returning optional object
+      // {
+      //   var megaphone = Futures.asyncMaybeNewMegaphone(true).get();
+      //   assert megaphone != null;
     
-        var not_megaphone = Futures.asyncMaybeNewMegaphone(false).get();
-        assert not_megaphone == null;
-      }
+      //   var not_megaphone = Futures.asyncMaybeNewMegaphone(false).get();
+      //   assert not_megaphone == null;
+      // }
 
-      // Test async methods in trait interfaces
-      {
-        var traits = Futures.getSayAfterTraits();
-        var time = measureTimeMillis(() -> {
-          var result1 = traits.get(0).sayAfter((short)100, "Alice").get();
-          var result2 = traits.get(1).sayAfter((short)100, "Bob").get();
+      // // Test async methods in trait interfaces
+      // {
+      //   var traits = Futures.getSayAfterTraits();
+      //   var time = measureTimeMillis(() -> {
+      //     var result1 = traits.get(0).sayAfter((short)100, "Alice").get();
+      //     var result2 = traits.get(1).sayAfter((short)100, "Bob").get();
 
-          assert result1.equals("Hello, Alice!");
-          assert result2.equals("Hello, Bob!");
-        });
+      //     assert result1.equals("Hello, Alice!");
+      //     assert result2.equals("Hello, Bob!");
+      //   });
 
-        assertApproximateTime(time, 200, "async trait methods");
-      }
+      //   assertApproximateTime(time, 200, "async trait methods");
+      // }
 
-      // Test async methods in UDL-defined trait interfaces
-      {
-        var traits = Futures.getSayAfterUdlTraits();
-        var time = measureTimeMillis(() -> {
-          var result1 = traits.get(0).sayAfter((short)100, "Alice").get();
-          var result2 = traits.get(1).sayAfter((short)100, "Bob").get();
+      // // Test async methods in UDL-defined trait interfaces
+      // {
+      //   var traits = Futures.getSayAfterUdlTraits();
+      //   var time = measureTimeMillis(() -> {
+      //     var result1 = traits.get(0).sayAfter((short)100, "Alice").get();
+      //     var result2 = traits.get(1).sayAfter((short)100, "Bob").get();
 
-          assert result1.equals("Hello, Alice!");
-          assert result2.equals("Hello, Bob!");
-        });
+      //     assert result1.equals("Hello, Alice!");
+      //     assert result2.equals("Hello, Bob!");
+      //   });
 
-        assertApproximateTime(time, 200, "async UDL methods");
-      }
+      //   assertApproximateTime(time, 200, "async UDL methods");
+      // }
 
       // Test foreign implemented async trait methods
       {
@@ -278,140 +278,140 @@ public class TestFixtureFutures {
         assert endingHandleCount == 0 : MessageFormat.format("{0} current handle count != 0", endingHandleCount);
       }
 
-      // Test with the Tokio runtime.
-      {
-        var time = measureTimeMillis(() -> {
-          var resultAlice = Futures.sayAfterWithTokio((short)200, "Alice").get();
+      // // Test with the Tokio runtime.
+      // {
+      //   var time = measureTimeMillis(() -> {
+      //     var resultAlice = Futures.sayAfterWithTokio((short)200, "Alice").get();
 
-          assert resultAlice.equals("Hello, Alice (with Tokio)!");
-        });
+      //     assert resultAlice.equals("Hello, Alice (with Tokio)!");
+      //   });
 
-        assertApproximateTime(time, 200, "with tokio runtime");
-      }
+      //   assertApproximateTime(time, 200, "with tokio runtime");
+      // }
 
-      // Test fallible function/method
-      {
-        var time1 = measureTimeMillis(() -> {
-          try {
-            Futures.fallibleMe(false).get();
-            assert true;
-          } catch (Exception e) {
-            assert false; // should never be reached
-          }
-        });
+      // // Test fallible function/method
+      // {
+      //   var time1 = measureTimeMillis(() -> {
+      //     try {
+      //       Futures.fallibleMe(false).get();
+      //       assert true;
+      //     } catch (Exception e) {
+      //       assert false; // should never be reached
+      //     }
+      //   });
 
-        System.out.print(MessageFormat.format("fallible function (with result): {0}ms", time1));
-        assert time1 < 100;
-        System.out.println(" ... ok");
+      //   System.out.print(MessageFormat.format("fallible function (with result): {0}ms", time1));
+      //   assert time1 < 100;
+      //   System.out.println(" ... ok");
 
-        var time2 = measureTimeMillis(() -> {
-          try {
-            Futures.fallibleMe(true).get();
-            assert false; // should never be reached
-          } catch (Exception e) {
-            assert true;
-          }
-        });
+      //   var time2 = measureTimeMillis(() -> {
+      //     try {
+      //       Futures.fallibleMe(true).get();
+      //       assert false; // should never be reached
+      //     } catch (Exception e) {
+      //       assert true;
+      //     }
+      //   });
 
-        System.out.print(MessageFormat.format("fallible function (with exception): {0}ms", time2));
-        assert time2 < 100;
-        System.out.println(" ... ok");
+      //   System.out.print(MessageFormat.format("fallible function (with exception): {0}ms", time2));
+      //   assert time2 < 100;
+      //   System.out.println(" ... ok");
 
-        var megaphone = Futures.newMegaphone();
+      //   var megaphone = Futures.newMegaphone();
 
-        var time3 = measureTimeMillis(() -> {
-          try {
-            megaphone.fallibleMe(false).get();
-            assert true;
-          } catch (Exception e) {
-            assert false; // should never be reached
-          }
-        });
+      //   var time3 = measureTimeMillis(() -> {
+      //     try {
+      //       megaphone.fallibleMe(false).get();
+      //       assert true;
+      //     } catch (Exception e) {
+      //       assert false; // should never be reached
+      //     }
+      //   });
 
-        System.out.print(MessageFormat.format("fallible method (with result): {0}ms", time3));
-        assert time3 < 100;
-        System.out.println(" ... ok");
+      //   System.out.print(MessageFormat.format("fallible method (with result): {0}ms", time3));
+      //   assert time3 < 100;
+      //   System.out.println(" ... ok");
         
-        var time4 = measureTimeMillis(() -> {
-          try {
-            megaphone.fallibleMe(true).get();
-            assert false; // should never be reached
-          } catch (Exception e) {
-            assert true;
-          }
-        });
+      //   var time4 = measureTimeMillis(() -> {
+      //     try {
+      //       megaphone.fallibleMe(true).get();
+      //       assert false; // should never be reached
+      //     } catch (Exception e) {
+      //       assert true;
+      //     }
+      //   });
 
-        System.out.print(MessageFormat.format("fallible method (with exception): {0}ms", time4));
-        assert time4 < 100;
-        System.out.println(" ... ok");
+      //   System.out.print(MessageFormat.format("fallible method (with exception): {0}ms", time4));
+      //   assert time4 < 100;
+      //   System.out.println(" ... ok");
 
-        Futures.fallibleStruct(false).get();
-        try {
-          Futures.fallibleStruct(true).get();
-          assert false; // should never be reached
-        } catch (Exception e) {
-          assert true;
-        }
-      }
+      //   Futures.fallibleStruct(false).get();
+      //   try {
+      //     Futures.fallibleStruct(true).get();
+      //     assert false; // should never be reached
+      //   } catch (Exception e) {
+      //     assert true;
+      //   }
+      // }
 
-      // Test record.
-      {
-        var time = measureTimeMillis(() -> {
-          var result = Futures.newMyRecord("foo", 42).get();
+      // // Test record.
+      // {
+      //   var time = measureTimeMillis(() -> {
+      //     var result = Futures.newMyRecord("foo", 42).get();
 
-          assert result.a().equals("foo");
-          assert result.b() == 42;
-        });
+      //     assert result.a().equals("foo");
+      //     assert result.b() == 42;
+      //   });
 
-        System.out.print(MessageFormat.format("record: {0}ms", time));
-        assert time < 100;
-        System.out.println(" ... ok");
-      }
+      //   System.out.print(MessageFormat.format("record: {0}ms", time));
+      //   assert time < 100;
+      //   System.out.println(" ... ok");
+      // }
 
-      // Test a broken sleep.
-      {
-        var time = measureTimeMillis(() -> {
-          Futures.brokenSleep((short)100, (short)0).get(); // calls the waker twice immediately
-          Futures.sleep((short)100).get(); // wait for possible failure
+      // // Test a broken sleep.
+      // {
+      //   var time = measureTimeMillis(() -> {
+      //     Futures.brokenSleep((short)100, (short)0).get(); // calls the waker twice immediately
+      //     Futures.sleep((short)100).get(); // wait for possible failure
 
-          Futures.brokenSleep((short)100, (short)100).get(); // calls the waker a second time after 1s
-          Futures.sleep((short)200).get(); // wait for possible failure
-        });
+      //     Futures.brokenSleep((short)100, (short)100).get(); // calls the waker a second time after 1s
+      //     Futures.sleep((short)200).get(); // wait for possible failure
+      //   });
 
-        assertApproximateTime(time, 500, "broken sleep");
-      }
+      //   assertApproximateTime(time, 500, "broken sleep");
+      // }
 
-      // Test a future that uses a lock and that is cancelled.
-      {
-        var time = measureTimeMillis(() -> {
-          var job = Futures.useSharedResource(new SharedResourceOptions((short)5000, (short)100));
+      // // Test a future that uses a lock and that is cancelled.
+      // {
+      //   var time = measureTimeMillis(() -> {
+      //     var job = Futures.useSharedResource(new SharedResourceOptions((short)5000, (short)100));
 
-          // Wait some time to ensure the task has locked the shared resource
-          TestFixtureFutures.delay(50).get();
-          // Cancel the job before the shared resource has been released.
-          job.cancel(true);
+      //     // Wait some time to ensure the task has locked the shared resource
+      //     TestFixtureFutures.delay(50).get();
+      //     // Cancel the job before the shared resource has been released.
+      //     job.cancel(true);
 
-          // Try accessing the shared resource again. The initial task should release the shared resource before the
-          // timeout expires.
-          Futures.useSharedResource(new SharedResourceOptions((short)0, (short)1000)).get();
-        });
+      //     // Try accessing the shared resource again. The initial task should release the shared resource before the
+      //     // timeout expires.
+      //     Futures.useSharedResource(new SharedResourceOptions((short)0, (short)1000)).get();
+      //   });
 
-        System.out.println(MessageFormat.format("useSharedResource: {0}ms", time));
-      }
+      //   System.out.println(MessageFormat.format("useSharedResource: {0}ms", time));
+      // }
 
-      // Test a future that uses a lock and that is not cancelled.
-      {
-        var time = measureTimeMillis(() -> {
-          // spawn both at the same time so they contend for the resource
-          var f1 = Futures.useSharedResource(new SharedResourceOptions((short)100, (short)1000));
-          var f2 = Futures.useSharedResource(new SharedResourceOptions((short)0, (short)1000));
+      // // Test a future that uses a lock and that is not cancelled.
+      // {
+      //   var time = measureTimeMillis(() -> {
+      //     // spawn both at the same time so they contend for the resource
+      //     var f1 = Futures.useSharedResource(new SharedResourceOptions((short)100, (short)1000));
+      //     var f2 = Futures.useSharedResource(new SharedResourceOptions((short)0, (short)1000));
 
-          f1.get();
-          f2.get();
-        });
+      //     f1.get();
+      //     f2.get();
+      //   });
 
-        System.out.println(MessageFormat.format("useSharedResource (not cancelled): {0}ms", time));
-      }
+      //   System.out.println(MessageFormat.format("useSharedResource (not cancelled): {0}ms", time));
+      // }
     } finally {
       // bring down the scheduler, if it's not shut down it'll hold the main thread open.
       scheduler.shutdown();

--- a/tests/scripts/TestFixtureFutures/TestFixtureFutures.java
+++ b/tests/scripts/TestFixtureFutures/TestFixtureFutures.java
@@ -9,9 +9,6 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
 public class TestFixtureFutures {
-  // static {
-  //     com.sun.jna.Native.setProtected(true);
-  // }
   private static final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1);
 
   // emulating Kotlin's `delay` non-blocking sleep

--- a/tests/scripts/TestFixtureFutures/TestFixtureFutures.java
+++ b/tests/scripts/TestFixtureFutures/TestFixtureFutures.java
@@ -279,7 +279,7 @@ public class TestFixtureFutures {
             emptyHandlesFuture.complete(null);
           }
         }, 0, 10, TimeUnit.MILLISECONDS);
-        emptyHandlesFuture.get(10000, TimeUnit.MILLISECONDS);
+        emptyHandlesFuture.get(100000, TimeUnit.MILLISECONDS);
         checkHandles.cancel(true);
         var endingHandleCount = UniffiAsyncHelpers.uniffiForeignFutureHandleCount();
         assert endingHandleCount == 0 : MessageFormat.format("{0} current handle count != 0", endingHandleCount);

--- a/tests/scripts/TestFixtureFutures/TestFixtureFutures.java
+++ b/tests/scripts/TestFixtureFutures/TestFixtureFutures.java
@@ -57,127 +57,127 @@ public class TestFixtureFutures {
         System.out.println(MessageFormat.format("init time: {0}ms", time));
       }
 
-      // // Test `always_ready`
-      // {
-      //   var time = measureTimeMillis(() -> {
-      //       var result = Futures.alwaysReady().get();
-      //       assert result.equals(true);
-      //   });
+      // Test `always_ready`
+      {
+        var time = measureTimeMillis(() -> {
+            var result = Futures.alwaysReady().get();
+            assert result.equals(true);
+        });
 
-      //   assertReturnsImmediately(time, "always_ready");
-      // }
+        assertReturnsImmediately(time, "always_ready");
+      }
 
-      // // Test `void`.
-      // {
-      //   var time = measureTimeMillis(() -> {
-      //     var result = Futures._void().get();
+      // Test `void`.
+      {
+        var time = measureTimeMillis(() -> {
+          var result = Futures._void().get();
 
-      //     assert result == null;
-      //   });
+          assert result == null;
+        });
 
-      //   assertReturnsImmediately(time, "void");
-      // }
+        assertReturnsImmediately(time, "void");
+      }
 
-      // // Test `sleep`.
-      // {
-      //   var time = measureTimeMillis(() -> {
-      //     Futures.sleep((short)200).get();
-      //   });
+      // Test `sleep`.
+      {
+        var time = measureTimeMillis(() -> {
+          Futures.sleep((short)200).get();
+        });
 
-      //   assertApproximateTime(time, 200, "sleep");
-      // }
+        assertApproximateTime(time, 200, "sleep");
+      }
     
-      // // Test sequential futures.
-      // {
-      //   var time = measureTimeMillis(() -> {
-      //     var aliceResult = Futures.sayAfter((short)100, "Alice").get();
-      //     var bobResult = Futures.sayAfter((short)200, "Bob").get();
+      // Test sequential futures.
+      {
+        var time = measureTimeMillis(() -> {
+          var aliceResult = Futures.sayAfter((short)100, "Alice").get();
+          var bobResult = Futures.sayAfter((short)200, "Bob").get();
 
-      //     assert aliceResult.equals("Hello, Alice!");
-      //     assert bobResult.equals("Hello, Bob!");
-      //   });
+          assert aliceResult.equals("Hello, Alice!");
+          assert bobResult.equals("Hello, Bob!");
+        });
 
-      //   assertApproximateTime(time, 300, "sequential future");
-      // }
+        assertApproximateTime(time, 300, "sequential future");
+      }
 
-      // // Test concurrent futures.
-      // {
-      //   var time = measureTimeMillis(() -> {
-      //     var alice = Futures.sayAfter((short)100, "Alice");
-      //     var bob = Futures.sayAfter((short)200, "Bob");
+      // Test concurrent futures.
+      {
+        var time = measureTimeMillis(() -> {
+          var alice = Futures.sayAfter((short)100, "Alice");
+          var bob = Futures.sayAfter((short)200, "Bob");
 
-      //     assert alice.get().equals("Hello, Alice!");
-      //     assert bob.get().equals("Hello, Bob!");
-      //   });
+          assert alice.get().equals("Hello, Alice!");
+          assert bob.get().equals("Hello, Bob!");
+        });
     
-      //   assertApproximateTime(time, 200, "concurrent future");
-      // }
+        assertApproximateTime(time, 200, "concurrent future");
+      }
 
-      // // Test async methods.
-      // {
-      //   var megaphone = Futures.newMegaphone();
-      //   var time = measureTimeMillis(() -> {
-      //     var resultAlice = megaphone.sayAfter((short)200, "Alice").get();
+      // Test async methods.
+      {
+        var megaphone = Futures.newMegaphone();
+        var time = measureTimeMillis(() -> {
+          var resultAlice = megaphone.sayAfter((short)200, "Alice").get();
 
-      //     assert resultAlice.equals("HELLO, ALICE!");
-      //   });
+          assert resultAlice.equals("HELLO, ALICE!");
+        });
 
-      //   assertApproximateTime(time, 200, "async methods");
-      // }
+        assertApproximateTime(time, 200, "async methods");
+      }
 
-      // {
-      //   var megaphone = Futures.newMegaphone();
-      //   var time = measureTimeMillis(() -> {
-      //     var resultAlice = Futures.sayAfterWithMegaphone(megaphone, (short)200, "Alice").get();
+      {
+        var megaphone = Futures.newMegaphone();
+        var time = measureTimeMillis(() -> {
+          var resultAlice = Futures.sayAfterWithMegaphone(megaphone, (short)200, "Alice").get();
 
-      //     assert resultAlice.equals("HELLO, ALICE!");
-      //   });
+          assert resultAlice.equals("HELLO, ALICE!");
+        });
 
-      //   assertApproximateTime(time, 200, "async methods");
-      // }
+        assertApproximateTime(time, 200, "async methods");
+      }
 
-      // // Test async constructors
-      // {
-      //   var megaphone = Megaphone.secondary().get();
-      //   assert megaphone.sayAfter((short)1, "hi").get().equals("HELLO, HI!");
-      // }
+      // Test async constructors
+      {
+        var megaphone = Megaphone.secondary().get();
+        assert megaphone.sayAfter((short)1, "hi").get().equals("HELLO, HI!");
+      }
 
-      // // Test async method returning optional object
-      // {
-      //   var megaphone = Futures.asyncMaybeNewMegaphone(true).get();
-      //   assert megaphone != null;
+      // Test async method returning optional object
+      {
+        var megaphone = Futures.asyncMaybeNewMegaphone(true).get();
+        assert megaphone != null;
     
-      //   var not_megaphone = Futures.asyncMaybeNewMegaphone(false).get();
-      //   assert not_megaphone == null;
-      // }
+        var not_megaphone = Futures.asyncMaybeNewMegaphone(false).get();
+        assert not_megaphone == null;
+      }
 
-      // // Test async methods in trait interfaces
-      // {
-      //   var traits = Futures.getSayAfterTraits();
-      //   var time = measureTimeMillis(() -> {
-      //     var result1 = traits.get(0).sayAfter((short)100, "Alice").get();
-      //     var result2 = traits.get(1).sayAfter((short)100, "Bob").get();
+      // Test async methods in trait interfaces
+      {
+        var traits = Futures.getSayAfterTraits();
+        var time = measureTimeMillis(() -> {
+          var result1 = traits.get(0).sayAfter((short)100, "Alice").get();
+          var result2 = traits.get(1).sayAfter((short)100, "Bob").get();
 
-      //     assert result1.equals("Hello, Alice!");
-      //     assert result2.equals("Hello, Bob!");
-      //   });
+          assert result1.equals("Hello, Alice!");
+          assert result2.equals("Hello, Bob!");
+        });
 
-      //   assertApproximateTime(time, 200, "async trait methods");
-      // }
+        assertApproximateTime(time, 200, "async trait methods");
+      }
 
-      // // Test async methods in UDL-defined trait interfaces
-      // {
-      //   var traits = Futures.getSayAfterUdlTraits();
-      //   var time = measureTimeMillis(() -> {
-      //     var result1 = traits.get(0).sayAfter((short)100, "Alice").get();
-      //     var result2 = traits.get(1).sayAfter((short)100, "Bob").get();
+      // Test async methods in UDL-defined trait interfaces
+      {
+        var traits = Futures.getSayAfterUdlTraits();
+        var time = measureTimeMillis(() -> {
+          var result1 = traits.get(0).sayAfter((short)100, "Alice").get();
+          var result2 = traits.get(1).sayAfter((short)100, "Bob").get();
 
-      //     assert result1.equals("Hello, Alice!");
-      //     assert result2.equals("Hello, Bob!");
-      //   });
+          assert result1.equals("Hello, Alice!");
+          assert result2.equals("Hello, Bob!");
+        });
 
-      //   assertApproximateTime(time, 200, "async UDL methods");
-      // }
+        assertApproximateTime(time, 200, "async UDL methods");
+      }
 
       // Test foreign implemented async trait methods
       {
@@ -232,7 +232,7 @@ public class TestFixtureFutures {
 
         var traitObj = new JavaAsyncParser();
         var startingHandleCount = UniffiAsyncHelpers.uniffiForeignFutureHandleCount();
-        assert startingHandleCount == 0 : MessageFormat.format("{0} current handle count != 0", startingHandleCount);
+        assert startingHandleCount == 0 : MessageFormat.format("{0} starting handle count != 0", startingHandleCount);
         assert Futures.asStringUsingTrait(traitObj, 1, 42).get().equals("42");
         assert Futures.tryFromStringUsingTrait(traitObj, 1, "42").get().equals(42);
         try {
@@ -278,140 +278,140 @@ public class TestFixtureFutures {
         assert endingHandleCount == 0 : MessageFormat.format("{0} current handle count != 0", endingHandleCount);
       }
 
-      // // Test with the Tokio runtime.
-      // {
-      //   var time = measureTimeMillis(() -> {
-      //     var resultAlice = Futures.sayAfterWithTokio((short)200, "Alice").get();
+      // Test with the Tokio runtime.
+      {
+        var time = measureTimeMillis(() -> {
+          var resultAlice = Futures.sayAfterWithTokio((short)200, "Alice").get();
 
-      //     assert resultAlice.equals("Hello, Alice (with Tokio)!");
-      //   });
+          assert resultAlice.equals("Hello, Alice (with Tokio)!");
+        });
 
-      //   assertApproximateTime(time, 200, "with tokio runtime");
-      // }
+        assertApproximateTime(time, 200, "with tokio runtime");
+      }
 
-      // // Test fallible function/method
-      // {
-      //   var time1 = measureTimeMillis(() -> {
-      //     try {
-      //       Futures.fallibleMe(false).get();
-      //       assert true;
-      //     } catch (Exception e) {
-      //       assert false; // should never be reached
-      //     }
-      //   });
+      // Test fallible function/method
+      {
+        var time1 = measureTimeMillis(() -> {
+          try {
+            Futures.fallibleMe(false).get();
+            assert true;
+          } catch (Exception e) {
+            assert false; // should never be reached
+          }
+        });
 
-      //   System.out.print(MessageFormat.format("fallible function (with result): {0}ms", time1));
-      //   assert time1 < 100;
-      //   System.out.println(" ... ok");
+        System.out.print(MessageFormat.format("fallible function (with result): {0}ms", time1));
+        assert time1 < 100;
+        System.out.println(" ... ok");
 
-      //   var time2 = measureTimeMillis(() -> {
-      //     try {
-      //       Futures.fallibleMe(true).get();
-      //       assert false; // should never be reached
-      //     } catch (Exception e) {
-      //       assert true;
-      //     }
-      //   });
+        var time2 = measureTimeMillis(() -> {
+          try {
+            Futures.fallibleMe(true).get();
+            assert false; // should never be reached
+          } catch (Exception e) {
+            assert true;
+          }
+        });
 
-      //   System.out.print(MessageFormat.format("fallible function (with exception): {0}ms", time2));
-      //   assert time2 < 100;
-      //   System.out.println(" ... ok");
+        System.out.print(MessageFormat.format("fallible function (with exception): {0}ms", time2));
+        assert time2 < 100;
+        System.out.println(" ... ok");
 
-      //   var megaphone = Futures.newMegaphone();
+        var megaphone = Futures.newMegaphone();
 
-      //   var time3 = measureTimeMillis(() -> {
-      //     try {
-      //       megaphone.fallibleMe(false).get();
-      //       assert true;
-      //     } catch (Exception e) {
-      //       assert false; // should never be reached
-      //     }
-      //   });
+        var time3 = measureTimeMillis(() -> {
+          try {
+            megaphone.fallibleMe(false).get();
+            assert true;
+          } catch (Exception e) {
+            assert false; // should never be reached
+          }
+        });
 
-      //   System.out.print(MessageFormat.format("fallible method (with result): {0}ms", time3));
-      //   assert time3 < 100;
-      //   System.out.println(" ... ok");
+        System.out.print(MessageFormat.format("fallible method (with result): {0}ms", time3));
+        assert time3 < 100;
+        System.out.println(" ... ok");
         
-      //   var time4 = measureTimeMillis(() -> {
-      //     try {
-      //       megaphone.fallibleMe(true).get();
-      //       assert false; // should never be reached
-      //     } catch (Exception e) {
-      //       assert true;
-      //     }
-      //   });
+        var time4 = measureTimeMillis(() -> {
+          try {
+            megaphone.fallibleMe(true).get();
+            assert false; // should never be reached
+          } catch (Exception e) {
+            assert true;
+          }
+        });
 
-      //   System.out.print(MessageFormat.format("fallible method (with exception): {0}ms", time4));
-      //   assert time4 < 100;
-      //   System.out.println(" ... ok");
+        System.out.print(MessageFormat.format("fallible method (with exception): {0}ms", time4));
+        assert time4 < 100;
+        System.out.println(" ... ok");
 
-      //   Futures.fallibleStruct(false).get();
-      //   try {
-      //     Futures.fallibleStruct(true).get();
-      //     assert false; // should never be reached
-      //   } catch (Exception e) {
-      //     assert true;
-      //   }
-      // }
+        Futures.fallibleStruct(false).get();
+        try {
+          Futures.fallibleStruct(true).get();
+          assert false; // should never be reached
+        } catch (Exception e) {
+          assert true;
+        }
+      }
 
-      // // Test record.
-      // {
-      //   var time = measureTimeMillis(() -> {
-      //     var result = Futures.newMyRecord("foo", 42).get();
+      // Test record.
+      {
+        var time = measureTimeMillis(() -> {
+          var result = Futures.newMyRecord("foo", 42).get();
 
-      //     assert result.a().equals("foo");
-      //     assert result.b() == 42;
-      //   });
+          assert result.a().equals("foo");
+          assert result.b() == 42;
+        });
 
-      //   System.out.print(MessageFormat.format("record: {0}ms", time));
-      //   assert time < 100;
-      //   System.out.println(" ... ok");
-      // }
+        System.out.print(MessageFormat.format("record: {0}ms", time));
+        assert time < 100;
+        System.out.println(" ... ok");
+      }
 
-      // // Test a broken sleep.
-      // {
-      //   var time = measureTimeMillis(() -> {
-      //     Futures.brokenSleep((short)100, (short)0).get(); // calls the waker twice immediately
-      //     Futures.sleep((short)100).get(); // wait for possible failure
+      // Test a broken sleep.
+      {
+        var time = measureTimeMillis(() -> {
+          Futures.brokenSleep((short)100, (short)0).get(); // calls the waker twice immediately
+          Futures.sleep((short)100).get(); // wait for possible failure
 
-      //     Futures.brokenSleep((short)100, (short)100).get(); // calls the waker a second time after 1s
-      //     Futures.sleep((short)200).get(); // wait for possible failure
-      //   });
+          Futures.brokenSleep((short)100, (short)100).get(); // calls the waker a second time after 1s
+          Futures.sleep((short)200).get(); // wait for possible failure
+        });
 
-      //   assertApproximateTime(time, 500, "broken sleep");
-      // }
+        assertApproximateTime(time, 500, "broken sleep");
+      }
 
-      // // Test a future that uses a lock and that is cancelled.
-      // {
-      //   var time = measureTimeMillis(() -> {
-      //     var job = Futures.useSharedResource(new SharedResourceOptions((short)5000, (short)100));
+      // Test a future that uses a lock and that is cancelled.
+      {
+        var time = measureTimeMillis(() -> {
+          var job = Futures.useSharedResource(new SharedResourceOptions((short)5000, (short)100));
 
-      //     // Wait some time to ensure the task has locked the shared resource
-      //     TestFixtureFutures.delay(50).get();
-      //     // Cancel the job before the shared resource has been released.
-      //     job.cancel(true);
+          // Wait some time to ensure the task has locked the shared resource
+          TestFixtureFutures.delay(50).get();
+          // Cancel the job before the shared resource has been released.
+          job.cancel(true);
 
-      //     // Try accessing the shared resource again. The initial task should release the shared resource before the
-      //     // timeout expires.
-      //     Futures.useSharedResource(new SharedResourceOptions((short)0, (short)1000)).get();
-      //   });
+          // Try accessing the shared resource again. The initial task should release the shared resource before the
+          // timeout expires.
+          Futures.useSharedResource(new SharedResourceOptions((short)0, (short)1000)).get();
+        });
 
-      //   System.out.println(MessageFormat.format("useSharedResource: {0}ms", time));
-      // }
+        System.out.println(MessageFormat.format("useSharedResource: {0}ms", time));
+      }
 
-      // // Test a future that uses a lock and that is not cancelled.
-      // {
-      //   var time = measureTimeMillis(() -> {
-      //     // spawn both at the same time so they contend for the resource
-      //     var f1 = Futures.useSharedResource(new SharedResourceOptions((short)100, (short)1000));
-      //     var f2 = Futures.useSharedResource(new SharedResourceOptions((short)0, (short)1000));
+      // Test a future that uses a lock and that is not cancelled.
+      {
+        var time = measureTimeMillis(() -> {
+          // spawn both at the same time so they contend for the resource
+          var f1 = Futures.useSharedResource(new SharedResourceOptions((short)100, (short)1000));
+          var f2 = Futures.useSharedResource(new SharedResourceOptions((short)0, (short)1000));
 
-      //     f1.get();
-      //     f2.get();
-      //   });
+          f1.get();
+          f2.get();
+        });
 
-      //   System.out.println(MessageFormat.format("useSharedResource (not cancelled): {0}ms", time));
-      // }
+        System.out.println(MessageFormat.format("useSharedResource (not cancelled): {0}ms", time));
+      }
     } finally {
       // bring down the scheduler, if it's not shut down it'll hold the main thread open.
       scheduler.shutdown();

--- a/tests/scripts/TestFixtureFutures/TestFixtureFutures.java
+++ b/tests/scripts/TestFixtureFutures/TestFixtureFutures.java
@@ -57,127 +57,127 @@ public class TestFixtureFutures {
         System.out.println(MessageFormat.format("init time: {0}ms", time));
       }
 
-      // // Test `always_ready`
-      // {
-      //   var time = measureTimeMillis(() -> {
-      //       var result = Futures.alwaysReady().get();
-      //       assert result.equals(true);
-      //   });
+      // Test `always_ready`
+      {
+        var time = measureTimeMillis(() -> {
+            var result = Futures.alwaysReady().get();
+            assert result.equals(true);
+        });
 
-      //   assertReturnsImmediately(time, "always_ready");
-      // }
+        assertReturnsImmediately(time, "always_ready");
+      }
 
-      // // Test `void`.
-      // {
-      //   var time = measureTimeMillis(() -> {
-      //     var result = Futures._void().get();
+      // Test `void`.
+      {
+        var time = measureTimeMillis(() -> {
+          var result = Futures._void().get();
 
-      //     assert result == null;
-      //   });
+          assert result == null;
+        });
 
-      //   assertReturnsImmediately(time, "void");
-      // }
+        assertReturnsImmediately(time, "void");
+      }
 
-      // // Test `sleep`.
-      // {
-      //   var time = measureTimeMillis(() -> {
-      //     Futures.sleep((short)200).get();
-      //   });
+      // Test `sleep`.
+      {
+        var time = measureTimeMillis(() -> {
+          Futures.sleep((short)200).get();
+        });
 
-      //   assertApproximateTime(time, 200, "sleep");
-      // }
+        assertApproximateTime(time, 200, "sleep");
+      }
     
-      // // Test sequential futures.
-      // {
-      //   var time = measureTimeMillis(() -> {
-      //     var aliceResult = Futures.sayAfter((short)100, "Alice").get();
-      //     var bobResult = Futures.sayAfter((short)200, "Bob").get();
+      // Test sequential futures.
+      {
+        var time = measureTimeMillis(() -> {
+          var aliceResult = Futures.sayAfter((short)100, "Alice").get();
+          var bobResult = Futures.sayAfter((short)200, "Bob").get();
 
-      //     assert aliceResult.equals("Hello, Alice!");
-      //     assert bobResult.equals("Hello, Bob!");
-      //   });
+          assert aliceResult.equals("Hello, Alice!");
+          assert bobResult.equals("Hello, Bob!");
+        });
 
-      //   assertApproximateTime(time, 300, "sequential future");
-      // }
+        assertApproximateTime(time, 300, "sequential future");
+      }
 
-      // // Test concurrent futures.
-      // {
-      //   var time = measureTimeMillis(() -> {
-      //     var alice = Futures.sayAfter((short)100, "Alice");
-      //     var bob = Futures.sayAfter((short)200, "Bob");
+      // Test concurrent futures.
+      {
+        var time = measureTimeMillis(() -> {
+          var alice = Futures.sayAfter((short)100, "Alice");
+          var bob = Futures.sayAfter((short)200, "Bob");
 
-      //     assert alice.get().equals("Hello, Alice!");
-      //     assert bob.get().equals("Hello, Bob!");
-      //   });
+          assert alice.get().equals("Hello, Alice!");
+          assert bob.get().equals("Hello, Bob!");
+        });
     
-      //   assertApproximateTime(time, 200, "concurrent future");
-      // }
+        assertApproximateTime(time, 200, "concurrent future");
+      }
 
-      // // Test async methods.
-      // {
-      //   var megaphone = Futures.newMegaphone();
-      //   var time = measureTimeMillis(() -> {
-      //     var resultAlice = megaphone.sayAfter((short)200, "Alice").get();
+      // Test async methods.
+      {
+        var megaphone = Futures.newMegaphone();
+        var time = measureTimeMillis(() -> {
+          var resultAlice = megaphone.sayAfter((short)200, "Alice").get();
 
-      //     assert resultAlice.equals("HELLO, ALICE!");
-      //   });
+          assert resultAlice.equals("HELLO, ALICE!");
+        });
 
-      //   assertApproximateTime(time, 200, "async methods");
-      // }
+        assertApproximateTime(time, 200, "async methods");
+      }
 
-      // {
-      //   var megaphone = Futures.newMegaphone();
-      //   var time = measureTimeMillis(() -> {
-      //     var resultAlice = Futures.sayAfterWithMegaphone(megaphone, (short)200, "Alice").get();
+      {
+        var megaphone = Futures.newMegaphone();
+        var time = measureTimeMillis(() -> {
+          var resultAlice = Futures.sayAfterWithMegaphone(megaphone, (short)200, "Alice").get();
 
-      //     assert resultAlice.equals("HELLO, ALICE!");
-      //   });
+          assert resultAlice.equals("HELLO, ALICE!");
+        });
 
-      //   assertApproximateTime(time, 200, "async methods");
-      // }
+        assertApproximateTime(time, 200, "async methods");
+      }
 
-      // // Test async constructors
-      // {
-      //   var megaphone = Megaphone.secondary().get();
-      //   assert megaphone.sayAfter((short)1, "hi").get().equals("HELLO, HI!");
-      // }
+      // Test async constructors
+      {
+        var megaphone = Megaphone.secondary().get();
+        assert megaphone.sayAfter((short)1, "hi").get().equals("HELLO, HI!");
+      }
 
-      // // Test async method returning optional object
-      // {
-      //   var megaphone = Futures.asyncMaybeNewMegaphone(true).get();
-      //   assert megaphone != null;
+      // Test async method returning optional object
+      {
+        var megaphone = Futures.asyncMaybeNewMegaphone(true).get();
+        assert megaphone != null;
     
-      //   var not_megaphone = Futures.asyncMaybeNewMegaphone(false).get();
-      //   assert not_megaphone == null;
-      // }
+        var not_megaphone = Futures.asyncMaybeNewMegaphone(false).get();
+        assert not_megaphone == null;
+      }
 
-      // // Test async methods in trait interfaces
-      // {
-      //   var traits = Futures.getSayAfterTraits();
-      //   var time = measureTimeMillis(() -> {
-      //     var result1 = traits.get(0).sayAfter((short)100, "Alice").get();
-      //     var result2 = traits.get(1).sayAfter((short)100, "Bob").get();
+      // Test async methods in trait interfaces
+      {
+        var traits = Futures.getSayAfterTraits();
+        var time = measureTimeMillis(() -> {
+          var result1 = traits.get(0).sayAfter((short)100, "Alice").get();
+          var result2 = traits.get(1).sayAfter((short)100, "Bob").get();
 
-      //     assert result1.equals("Hello, Alice!");
-      //     assert result2.equals("Hello, Bob!");
-      //   });
+          assert result1.equals("Hello, Alice!");
+          assert result2.equals("Hello, Bob!");
+        });
 
-      //   assertApproximateTime(time, 200, "async trait methods");
-      // }
+        assertApproximateTime(time, 200, "async trait methods");
+      }
 
-      // // Test async methods in UDL-defined trait interfaces
-      // {
-      //   var traits = Futures.getSayAfterUdlTraits();
-      //   var time = measureTimeMillis(() -> {
-      //     var result1 = traits.get(0).sayAfter((short)100, "Alice").get();
-      //     var result2 = traits.get(1).sayAfter((short)100, "Bob").get();
+      // Test async methods in UDL-defined trait interfaces
+      {
+        var traits = Futures.getSayAfterUdlTraits();
+        var time = measureTimeMillis(() -> {
+          var result1 = traits.get(0).sayAfter((short)100, "Alice").get();
+          var result2 = traits.get(1).sayAfter((short)100, "Bob").get();
 
-      //     assert result1.equals("Hello, Alice!");
-      //     assert result2.equals("Hello, Bob!");
-      //   });
+          assert result1.equals("Hello, Alice!");
+          assert result2.equals("Hello, Bob!");
+        });
 
-      //   assertApproximateTime(time, 200, "async UDL methods");
-      // }
+        assertApproximateTime(time, 200, "async UDL methods");
+      }
 
       // Test foreign implemented async trait methods
       {
@@ -233,29 +233,29 @@ public class TestFixtureFutures {
         var traitObj = new JavaAsyncParser();
         var startingHandleCount = UniffiAsyncHelpers.uniffiForeignFutureHandleCount();
         assert startingHandleCount == 0 : MessageFormat.format("{0} starting handle count != 0", startingHandleCount);
-        assert Futures.asStringUsingTrait(traitObj, 1, 42).get().equals("42");
-        assert Futures.tryFromStringUsingTrait(traitObj, 1, "42").get().equals(42);
-        try {
-          Futures.tryFromStringUsingTrait(traitObj, 1, "fourty-two").get();
-          throw new RuntimeException("Expected last statement to throw");
-        } catch (ExecutionException e) {
-          if (e.getCause() instanceof ParserException.NotAnInt) {
-              // Expected
-          } else {
-            throw e;
-          }
-        }
-        try {
-          Futures.tryFromStringUsingTrait(traitObj, 1, "force-unexpected-exception").get();
-          throw new RuntimeException("Expected last statement to throw");
-        } catch (ExecutionException e) {
-          if (e.getCause() instanceof ParserException.UnexpectedException) {
-             // Expected
-          } else {
-             throw e;
-          }
-        }
-        Futures.delayUsingTrait(traitObj, 1).get();
+        // assert Futures.asStringUsingTrait(traitObj, 1, 42).get().equals("42");
+        // assert Futures.tryFromStringUsingTrait(traitObj, 1, "42").get().equals(42);
+        // try {
+        //   Futures.tryFromStringUsingTrait(traitObj, 1, "fourty-two").get();
+        //   throw new RuntimeException("Expected last statement to throw");
+        // } catch (ExecutionException e) {
+        //   if (e.getCause() instanceof ParserException.NotAnInt) {
+        //       // Expected
+        //   } else {
+        //     throw e;
+        //   }
+        // }
+        // try {
+        //   Futures.tryFromStringUsingTrait(traitObj, 1, "force-unexpected-exception").get();
+        //   throw new RuntimeException("Expected last statement to throw");
+        // } catch (ExecutionException e) {
+        //   if (e.getCause() instanceof ParserException.UnexpectedException) {
+        //      // Expected
+        //   } else {
+        //      throw e;
+        //   }
+        // }
+        // Futures.delayUsingTrait(traitObj, 1).get();
         try {
           Futures.tryDelayUsingTrait(traitObj, "one").get();
           throw new RuntimeException("Expected last statement to throw");
@@ -266,152 +266,152 @@ public class TestFixtureFutures {
             throw e;
           }
         }
-        var completedDelaysBefore = traitObj.completedDelays;
-        Futures.cancelDelayUsingTrait(traitObj, 50).get();
-        // sleep long enough so that the `delay()` call would finish if it wasn't cancelled.
-        TestFixtureFutures.delay(200).get();
-        // If the task was cancelled, then completedDelays won't have increased
-        assert traitObj.completedDelays == completedDelaysBefore : MessageFormat.format("{0} current delays != {1} delays before", traitObj.completedDelays, completedDelaysBefore);
+        // var completedDelaysBefore = traitObj.completedDelays;
+        // Futures.cancelDelayUsingTrait(traitObj, 50).get();
+        // // sleep long enough so that the `delay()` call would finish if it wasn't cancelled.
+        // TestFixtureFutures.delay(200).get();
+        // // If the task was cancelled, then completedDelays won't have increased
+        // assert traitObj.completedDelays == completedDelaysBefore : MessageFormat.format("{0} current delays != {1} delays before", traitObj.completedDelays, completedDelaysBefore);
 
         // Test that all handles were cleaned up
         var endingHandleCount = UniffiAsyncHelpers.uniffiForeignFutureHandleCount();
         assert endingHandleCount == 0 : MessageFormat.format("{0} current handle count != 0", endingHandleCount);
       }
 
-      // // Test with the Tokio runtime.
-      // {
-      //   var time = measureTimeMillis(() -> {
-      //     var resultAlice = Futures.sayAfterWithTokio((short)200, "Alice").get();
+      // Test with the Tokio runtime.
+      {
+        var time = measureTimeMillis(() -> {
+          var resultAlice = Futures.sayAfterWithTokio((short)200, "Alice").get();
 
-      //     assert resultAlice.equals("Hello, Alice (with Tokio)!");
-      //   });
+          assert resultAlice.equals("Hello, Alice (with Tokio)!");
+        });
 
-      //   assertApproximateTime(time, 200, "with tokio runtime");
-      // }
+        assertApproximateTime(time, 200, "with tokio runtime");
+      }
 
-      // // Test fallible function/method
-      // {
-      //   var time1 = measureTimeMillis(() -> {
-      //     try {
-      //       Futures.fallibleMe(false).get();
-      //       assert true;
-      //     } catch (Exception e) {
-      //       assert false; // should never be reached
-      //     }
-      //   });
+      // Test fallible function/method
+      {
+        var time1 = measureTimeMillis(() -> {
+          try {
+            Futures.fallibleMe(false).get();
+            assert true;
+          } catch (Exception e) {
+            assert false; // should never be reached
+          }
+        });
 
-      //   System.out.print(MessageFormat.format("fallible function (with result): {0}ms", time1));
-      //   assert time1 < 100;
-      //   System.out.println(" ... ok");
+        System.out.print(MessageFormat.format("fallible function (with result): {0}ms", time1));
+        assert time1 < 100;
+        System.out.println(" ... ok");
 
-      //   var time2 = measureTimeMillis(() -> {
-      //     try {
-      //       Futures.fallibleMe(true).get();
-      //       assert false; // should never be reached
-      //     } catch (Exception e) {
-      //       assert true;
-      //     }
-      //   });
+        var time2 = measureTimeMillis(() -> {
+          try {
+            Futures.fallibleMe(true).get();
+            assert false; // should never be reached
+          } catch (Exception e) {
+            assert true;
+          }
+        });
 
-      //   System.out.print(MessageFormat.format("fallible function (with exception): {0}ms", time2));
-      //   assert time2 < 100;
-      //   System.out.println(" ... ok");
+        System.out.print(MessageFormat.format("fallible function (with exception): {0}ms", time2));
+        assert time2 < 100;
+        System.out.println(" ... ok");
 
-      //   var megaphone = Futures.newMegaphone();
+        var megaphone = Futures.newMegaphone();
 
-      //   var time3 = measureTimeMillis(() -> {
-      //     try {
-      //       megaphone.fallibleMe(false).get();
-      //       assert true;
-      //     } catch (Exception e) {
-      //       assert false; // should never be reached
-      //     }
-      //   });
+        var time3 = measureTimeMillis(() -> {
+          try {
+            megaphone.fallibleMe(false).get();
+            assert true;
+          } catch (Exception e) {
+            assert false; // should never be reached
+          }
+        });
 
-      //   System.out.print(MessageFormat.format("fallible method (with result): {0}ms", time3));
-      //   assert time3 < 100;
-      //   System.out.println(" ... ok");
+        System.out.print(MessageFormat.format("fallible method (with result): {0}ms", time3));
+        assert time3 < 100;
+        System.out.println(" ... ok");
         
-      //   var time4 = measureTimeMillis(() -> {
-      //     try {
-      //       megaphone.fallibleMe(true).get();
-      //       assert false; // should never be reached
-      //     } catch (Exception e) {
-      //       assert true;
-      //     }
-      //   });
+        var time4 = measureTimeMillis(() -> {
+          try {
+            megaphone.fallibleMe(true).get();
+            assert false; // should never be reached
+          } catch (Exception e) {
+            assert true;
+          }
+        });
 
-      //   System.out.print(MessageFormat.format("fallible method (with exception): {0}ms", time4));
-      //   assert time4 < 100;
-      //   System.out.println(" ... ok");
+        System.out.print(MessageFormat.format("fallible method (with exception): {0}ms", time4));
+        assert time4 < 100;
+        System.out.println(" ... ok");
 
-      //   Futures.fallibleStruct(false).get();
-      //   try {
-      //     Futures.fallibleStruct(true).get();
-      //     assert false; // should never be reached
-      //   } catch (Exception e) {
-      //     assert true;
-      //   }
-      // }
+        Futures.fallibleStruct(false).get();
+        try {
+          Futures.fallibleStruct(true).get();
+          assert false; // should never be reached
+        } catch (Exception e) {
+          assert true;
+        }
+      }
 
-      // // Test record.
-      // {
-      //   var time = measureTimeMillis(() -> {
-      //     var result = Futures.newMyRecord("foo", 42).get();
+      // Test record.
+      {
+        var time = measureTimeMillis(() -> {
+          var result = Futures.newMyRecord("foo", 42).get();
 
-      //     assert result.a().equals("foo");
-      //     assert result.b() == 42;
-      //   });
+          assert result.a().equals("foo");
+          assert result.b() == 42;
+        });
 
-      //   System.out.print(MessageFormat.format("record: {0}ms", time));
-      //   assert time < 100;
-      //   System.out.println(" ... ok");
-      // }
+        System.out.print(MessageFormat.format("record: {0}ms", time));
+        assert time < 100;
+        System.out.println(" ... ok");
+      }
 
-      // // Test a broken sleep.
-      // {
-      //   var time = measureTimeMillis(() -> {
-      //     Futures.brokenSleep((short)100, (short)0).get(); // calls the waker twice immediately
-      //     Futures.sleep((short)100).get(); // wait for possible failure
+      // Test a broken sleep.
+      {
+        var time = measureTimeMillis(() -> {
+          Futures.brokenSleep((short)100, (short)0).get(); // calls the waker twice immediately
+          Futures.sleep((short)100).get(); // wait for possible failure
 
-      //     Futures.brokenSleep((short)100, (short)100).get(); // calls the waker a second time after 1s
-      //     Futures.sleep((short)200).get(); // wait for possible failure
-      //   });
+          Futures.brokenSleep((short)100, (short)100).get(); // calls the waker a second time after 1s
+          Futures.sleep((short)200).get(); // wait for possible failure
+        });
 
-      //   assertApproximateTime(time, 500, "broken sleep");
-      // }
+        assertApproximateTime(time, 500, "broken sleep");
+      }
 
-      // // Test a future that uses a lock and that is cancelled.
-      // {
-      //   var time = measureTimeMillis(() -> {
-      //     var job = Futures.useSharedResource(new SharedResourceOptions((short)5000, (short)100));
+      // Test a future that uses a lock and that is cancelled.
+      {
+        var time = measureTimeMillis(() -> {
+          var job = Futures.useSharedResource(new SharedResourceOptions((short)5000, (short)100));
 
-      //     // Wait some time to ensure the task has locked the shared resource
-      //     TestFixtureFutures.delay(50).get();
-      //     // Cancel the job before the shared resource has been released.
-      //     job.cancel(true);
+          // Wait some time to ensure the task has locked the shared resource
+          TestFixtureFutures.delay(50).get();
+          // Cancel the job before the shared resource has been released.
+          job.cancel(true);
 
-      //     // Try accessing the shared resource again. The initial task should release the shared resource before the
-      //     // timeout expires.
-      //     Futures.useSharedResource(new SharedResourceOptions((short)0, (short)1000)).get();
-      //   });
+          // Try accessing the shared resource again. The initial task should release the shared resource before the
+          // timeout expires.
+          Futures.useSharedResource(new SharedResourceOptions((short)0, (short)1000)).get();
+        });
 
-      //   System.out.println(MessageFormat.format("useSharedResource: {0}ms", time));
-      // }
+        System.out.println(MessageFormat.format("useSharedResource: {0}ms", time));
+      }
 
-      // // Test a future that uses a lock and that is not cancelled.
-      // {
-      //   var time = measureTimeMillis(() -> {
-      //     // spawn both at the same time so they contend for the resource
-      //     var f1 = Futures.useSharedResource(new SharedResourceOptions((short)100, (short)1000));
-      //     var f2 = Futures.useSharedResource(new SharedResourceOptions((short)0, (short)1000));
+      // Test a future that uses a lock and that is not cancelled.
+      {
+        var time = measureTimeMillis(() -> {
+          // spawn both at the same time so they contend for the resource
+          var f1 = Futures.useSharedResource(new SharedResourceOptions((short)100, (short)1000));
+          var f2 = Futures.useSharedResource(new SharedResourceOptions((short)0, (short)1000));
 
-      //     f1.get();
-      //     f2.get();
-      //   });
+          f1.get();
+          f2.get();
+        });
 
-      //   System.out.println(MessageFormat.format("useSharedResource (not cancelled): {0}ms", time));
-      // }
+        System.out.println(MessageFormat.format("useSharedResource (not cancelled): {0}ms", time));
+      }
     } finally {
       // bring down the scheduler, if it's not shut down it'll hold the main thread open.
       scheduler.shutdown();

--- a/tests/scripts/TestFixtureFutures/TestFixtureFutures.java
+++ b/tests/scripts/TestFixtureFutures/TestFixtureFutures.java
@@ -252,17 +252,17 @@ public class TestFixtureFutures {
         //      throw e;
         //   }
         // }
-        // Futures.delayUsingTrait(traitObj, 1).get();
-        // try {
-        //   Futures.tryDelayUsingTrait(traitObj, "one").get();
-        //   throw new RuntimeException("Expected last statement to throw");
-        // } catch (ExecutionException e) {
-        //   if (e.getCause() instanceof ParserException.NotAnInt) {
-        //     // Expected
-        //   } else {
-        //     throw e;
-        //   }
-        // }
+        Futures.delayUsingTrait(traitObj, 1).get();
+        try {
+          Futures.tryDelayUsingTrait(traitObj, "one").get();
+          throw new RuntimeException("Expected last statement to throw");
+        } catch (ExecutionException e) {
+          if (e.getCause() instanceof ParserException.NotAnInt) {
+            // Expected
+          } else {
+            throw e;
+          }
+        }
         var completedDelaysBefore = traitObj.completedDelays;
         Futures.cancelDelayUsingTrait(traitObj, 50).get();
         // sleep long enough so that the `delay()` call would finish if it wasn't cancelled.

--- a/tests/scripts/TestFixtureFutures/TestFixtureFutures.java
+++ b/tests/scripts/TestFixtureFutures/TestFixtureFutures.java
@@ -237,43 +237,43 @@ public class TestFixtureFutures {
         System.out.println("java test calling for trait method " + System.currentTimeMillis());
         assert Futures.tryFromStringUsingTrait(traitObj, 1, "42").get().equals(42);
         System.out.println("java test finished trait method " + System.currentTimeMillis());
-        try {
-          Futures.tryFromStringUsingTrait(traitObj, 1, "fourty-two").get();
-          throw new RuntimeException("Expected last statement to throw");
-        } catch (ExecutionException e) {
-          if (e.getCause() instanceof ParserException.NotAnInt) {
-              // Expected
-          } else {
-            throw e;
-          }
-        }
-        try {
-          Futures.tryFromStringUsingTrait(traitObj, 1, "force-unexpected-exception").get();
-          throw new RuntimeException("Expected last statement to throw");
-        } catch (ExecutionException e) {
-          if (e.getCause() instanceof ParserException.UnexpectedException) {
-             // Expected
-          } else {
-             throw e;
-          }
-        }
-        Futures.delayUsingTrait(traitObj, 1).get();
-        try {
-          Futures.tryDelayUsingTrait(traitObj, "one").get();
-          throw new RuntimeException("Expected last statement to throw");
-        } catch (ExecutionException e) {
-          if (e.getCause() instanceof ParserException.NotAnInt) {
-            // Expected
-          } else {
-            throw e;
-          }
-        }
-        var completedDelaysBefore = traitObj.completedDelays;
-        Futures.cancelDelayUsingTrait(traitObj, 50).get();
-        // sleep long enough so that the `delay()` call would finish if it wasn't cancelled.
-        TestFixtureFutures.delay(200).get();
-        // If the task was cancelled, then completedDelays won't have increased
-        assert traitObj.completedDelays == completedDelaysBefore : MessageFormat.format("{0} current delays != {1} delays before", traitObj.completedDelays, completedDelaysBefore);
+        // try {
+        //   Futures.tryFromStringUsingTrait(traitObj, 1, "fourty-two").get();
+        //   throw new RuntimeException("Expected last statement to throw");
+        // } catch (ExecutionException e) {
+        //   if (e.getCause() instanceof ParserException.NotAnInt) {
+        //       // Expected
+        //   } else {
+        //     throw e;
+        //   }
+        // }
+        // try {
+        //   Futures.tryFromStringUsingTrait(traitObj, 1, "force-unexpected-exception").get();
+        //   throw new RuntimeException("Expected last statement to throw");
+        // } catch (ExecutionException e) {
+        //   if (e.getCause() instanceof ParserException.UnexpectedException) {
+        //      // Expected
+        //   } else {
+        //      throw e;
+        //   }
+        // }
+        // Futures.delayUsingTrait(traitObj, 1).get();
+        // try {
+        //   Futures.tryDelayUsingTrait(traitObj, "one").get();
+        //   throw new RuntimeException("Expected last statement to throw");
+        // } catch (ExecutionException e) {
+        //   if (e.getCause() instanceof ParserException.NotAnInt) {
+        //     // Expected
+        //   } else {
+        //     throw e;
+        //   }
+        // }
+        // var completedDelaysBefore = traitObj.completedDelays;
+        // Futures.cancelDelayUsingTrait(traitObj, 50).get();
+        // // sleep long enough so that the `delay()` call would finish if it wasn't cancelled.
+        // TestFixtureFutures.delay(200).get();
+        // // If the task was cancelled, then completedDelays won't have increased
+        // assert traitObj.completedDelays == completedDelaysBefore : MessageFormat.format("{0} current delays != {1} delays before", traitObj.completedDelays, completedDelaysBefore);
 
         // Test that all handles were cleaned up
         System.gc();

--- a/tests/scripts/TestFixtureFutures/TestFixtureFutures.java
+++ b/tests/scripts/TestFixtureFutures/TestFixtureFutures.java
@@ -237,43 +237,43 @@ public class TestFixtureFutures {
         System.out.println("java test calling for trait method " + System.currentTimeMillis());
         assert Futures.tryFromStringUsingTrait(traitObj, 1, "42").get().equals(42);
         System.out.println("java test finished trait method " + System.currentTimeMillis());
-        // try {
-        //   Futures.tryFromStringUsingTrait(traitObj, 1, "fourty-two").get();
-        //   throw new RuntimeException("Expected last statement to throw");
-        // } catch (ExecutionException e) {
-        //   if (e.getCause() instanceof ParserException.NotAnInt) {
-        //       // Expected
-        //   } else {
-        //     throw e;
-        //   }
-        // }
-        // try {
-        //   Futures.tryFromStringUsingTrait(traitObj, 1, "force-unexpected-exception").get();
-        //   throw new RuntimeException("Expected last statement to throw");
-        // } catch (ExecutionException e) {
-        //   if (e.getCause() instanceof ParserException.UnexpectedException) {
-        //      // Expected
-        //   } else {
-        //      throw e;
-        //   }
-        // }
-        // Futures.delayUsingTrait(traitObj, 1).get();
-        // try {
-        //   Futures.tryDelayUsingTrait(traitObj, "one").get();
-        //   throw new RuntimeException("Expected last statement to throw");
-        // } catch (ExecutionException e) {
-        //   if (e.getCause() instanceof ParserException.NotAnInt) {
-        //     // Expected
-        //   } else {
-        //     throw e;
-        //   }
-        // }
-        // var completedDelaysBefore = traitObj.completedDelays;
-        // Futures.cancelDelayUsingTrait(traitObj, 50).get();
-        // // sleep long enough so that the `delay()` call would finish if it wasn't cancelled.
-        // TestFixtureFutures.delay(200).get();
-        // // If the task was cancelled, then completedDelays won't have increased
-        // assert traitObj.completedDelays == completedDelaysBefore : MessageFormat.format("{0} current delays != {1} delays before", traitObj.completedDelays, completedDelaysBefore);
+        try {
+          Futures.tryFromStringUsingTrait(traitObj, 1, "fourty-two").get();
+          throw new RuntimeException("Expected last statement to throw");
+        } catch (ExecutionException e) {
+          if (e.getCause() instanceof ParserException.NotAnInt) {
+              // Expected
+          } else {
+            throw e;
+          }
+        }
+        try {
+          Futures.tryFromStringUsingTrait(traitObj, 1, "force-unexpected-exception").get();
+          throw new RuntimeException("Expected last statement to throw");
+        } catch (ExecutionException e) {
+          if (e.getCause() instanceof ParserException.UnexpectedException) {
+             // Expected
+          } else {
+             throw e;
+          }
+        }
+        Futures.delayUsingTrait(traitObj, 1).get();
+        try {
+          Futures.tryDelayUsingTrait(traitObj, "one").get();
+          throw new RuntimeException("Expected last statement to throw");
+        } catch (ExecutionException e) {
+          if (e.getCause() instanceof ParserException.NotAnInt) {
+            // Expected
+          } else {
+            throw e;
+          }
+        }
+        var completedDelaysBefore = traitObj.completedDelays;
+        Futures.cancelDelayUsingTrait(traitObj, 50).get();
+        // sleep long enough so that the `delay()` call would finish if it wasn't cancelled.
+        TestFixtureFutures.delay(200).get();
+        // If the task was cancelled, then completedDelays won't have increased
+        assert traitObj.completedDelays == completedDelaysBefore : MessageFormat.format("{0} current delays != {1} delays before", traitObj.completedDelays, completedDelaysBefore);
 
         // Test that all handles were cleaned up
         System.gc();

--- a/tests/scripts/TestFixtureFutures/TestFixtureFutures.java
+++ b/tests/scripts/TestFixtureFutures/TestFixtureFutures.java
@@ -272,19 +272,6 @@ public class TestFixtureFutures {
         assert traitObj.completedDelays == completedDelaysBefore : MessageFormat.format("{0} current delays != {1} delays before", traitObj.completedDelays, completedDelaysBefore);
 
         // Test that all handles were cleaned up
-        // wait until they're gone or we've timed out
-        var emptyHandlesFuture = new CompletableFuture<>();
-        final ScheduledFuture<?> checkHandles = scheduler.scheduleAtFixedRate(() -> {
-          if (UniffiAsyncHelpers.uniffiForeignFutureHandleCount() == 0) {
-            emptyHandlesFuture.complete(null);
-          }
-        }, 0, 10, TimeUnit.MILLISECONDS);
-        try {
-        emptyHandlesFuture.get(100000, TimeUnit.MILLISECONDS);
-        } catch (Exception e) {
-          // man something is so wrong
-        }
-        checkHandles.cancel(true);
         var endingHandleCount = UniffiAsyncHelpers.uniffiForeignFutureHandleCount();
         assert endingHandleCount == 0 : MessageFormat.format("{0} current handle count != 0", endingHandleCount);
       }

--- a/tests/scripts/TestFixtureFutures/TestFixtureFutures.java
+++ b/tests/scripts/TestFixtureFutures/TestFixtureFutures.java
@@ -57,127 +57,127 @@ public class TestFixtureFutures {
         System.out.println(MessageFormat.format("init time: {0}ms", time));
       }
 
-      // Test `always_ready`
-      {
-        var time = measureTimeMillis(() -> {
-            var result = Futures.alwaysReady().get();
-            assert result.equals(true);
-        });
+      // // Test `always_ready`
+      // {
+      //   var time = measureTimeMillis(() -> {
+      //       var result = Futures.alwaysReady().get();
+      //       assert result.equals(true);
+      //   });
 
-        assertReturnsImmediately(time, "always_ready");
-      }
+      //   assertReturnsImmediately(time, "always_ready");
+      // }
 
-      // Test `void`.
-      {
-        var time = measureTimeMillis(() -> {
-          var result = Futures._void().get();
+      // // Test `void`.
+      // {
+      //   var time = measureTimeMillis(() -> {
+      //     var result = Futures._void().get();
 
-          assert result == null;
-        });
+      //     assert result == null;
+      //   });
 
-        assertReturnsImmediately(time, "void");
-      }
+      //   assertReturnsImmediately(time, "void");
+      // }
 
-      // Test `sleep`.
-      {
-        var time = measureTimeMillis(() -> {
-          Futures.sleep((short)200).get();
-        });
+      // // Test `sleep`.
+      // {
+      //   var time = measureTimeMillis(() -> {
+      //     Futures.sleep((short)200).get();
+      //   });
 
-        assertApproximateTime(time, 200, "sleep");
-      }
+      //   assertApproximateTime(time, 200, "sleep");
+      // }
     
-      // Test sequential futures.
-      {
-        var time = measureTimeMillis(() -> {
-          var aliceResult = Futures.sayAfter((short)100, "Alice").get();
-          var bobResult = Futures.sayAfter((short)200, "Bob").get();
+      // // Test sequential futures.
+      // {
+      //   var time = measureTimeMillis(() -> {
+      //     var aliceResult = Futures.sayAfter((short)100, "Alice").get();
+      //     var bobResult = Futures.sayAfter((short)200, "Bob").get();
 
-          assert aliceResult.equals("Hello, Alice!");
-          assert bobResult.equals("Hello, Bob!");
-        });
+      //     assert aliceResult.equals("Hello, Alice!");
+      //     assert bobResult.equals("Hello, Bob!");
+      //   });
 
-        assertApproximateTime(time, 300, "sequential future");
-      }
+      //   assertApproximateTime(time, 300, "sequential future");
+      // }
 
-      // Test concurrent futures.
-      {
-        var time = measureTimeMillis(() -> {
-          var alice = Futures.sayAfter((short)100, "Alice");
-          var bob = Futures.sayAfter((short)200, "Bob");
+      // // Test concurrent futures.
+      // {
+      //   var time = measureTimeMillis(() -> {
+      //     var alice = Futures.sayAfter((short)100, "Alice");
+      //     var bob = Futures.sayAfter((short)200, "Bob");
 
-          assert alice.get().equals("Hello, Alice!");
-          assert bob.get().equals("Hello, Bob!");
-        });
+      //     assert alice.get().equals("Hello, Alice!");
+      //     assert bob.get().equals("Hello, Bob!");
+      //   });
     
-        assertApproximateTime(time, 200, "concurrent future");
-      }
+      //   assertApproximateTime(time, 200, "concurrent future");
+      // }
 
-      // Test async methods.
-      {
-        var megaphone = Futures.newMegaphone();
-        var time = measureTimeMillis(() -> {
-          var resultAlice = megaphone.sayAfter((short)200, "Alice").get();
+      // // Test async methods.
+      // {
+      //   var megaphone = Futures.newMegaphone();
+      //   var time = measureTimeMillis(() -> {
+      //     var resultAlice = megaphone.sayAfter((short)200, "Alice").get();
 
-          assert resultAlice.equals("HELLO, ALICE!");
-        });
+      //     assert resultAlice.equals("HELLO, ALICE!");
+      //   });
 
-        assertApproximateTime(time, 200, "async methods");
-      }
+      //   assertApproximateTime(time, 200, "async methods");
+      // }
 
-      {
-        var megaphone = Futures.newMegaphone();
-        var time = measureTimeMillis(() -> {
-          var resultAlice = Futures.sayAfterWithMegaphone(megaphone, (short)200, "Alice").get();
+      // {
+      //   var megaphone = Futures.newMegaphone();
+      //   var time = measureTimeMillis(() -> {
+      //     var resultAlice = Futures.sayAfterWithMegaphone(megaphone, (short)200, "Alice").get();
 
-          assert resultAlice.equals("HELLO, ALICE!");
-        });
+      //     assert resultAlice.equals("HELLO, ALICE!");
+      //   });
 
-        assertApproximateTime(time, 200, "async methods");
-      }
+      //   assertApproximateTime(time, 200, "async methods");
+      // }
 
-      // Test async constructors
-      {
-        var megaphone = Megaphone.secondary().get();
-        assert megaphone.sayAfter((short)1, "hi").get().equals("HELLO, HI!");
-      }
+      // // Test async constructors
+      // {
+      //   var megaphone = Megaphone.secondary().get();
+      //   assert megaphone.sayAfter((short)1, "hi").get().equals("HELLO, HI!");
+      // }
 
-      // Test async method returning optional object
-      {
-        var megaphone = Futures.asyncMaybeNewMegaphone(true).get();
-        assert megaphone != null;
+      // // Test async method returning optional object
+      // {
+      //   var megaphone = Futures.asyncMaybeNewMegaphone(true).get();
+      //   assert megaphone != null;
     
-        var not_megaphone = Futures.asyncMaybeNewMegaphone(false).get();
-        assert not_megaphone == null;
-      }
+      //   var not_megaphone = Futures.asyncMaybeNewMegaphone(false).get();
+      //   assert not_megaphone == null;
+      // }
 
-      // Test async methods in trait interfaces
-      {
-        var traits = Futures.getSayAfterTraits();
-        var time = measureTimeMillis(() -> {
-          var result1 = traits.get(0).sayAfter((short)100, "Alice").get();
-          var result2 = traits.get(1).sayAfter((short)100, "Bob").get();
+      // // Test async methods in trait interfaces
+      // {
+      //   var traits = Futures.getSayAfterTraits();
+      //   var time = measureTimeMillis(() -> {
+      //     var result1 = traits.get(0).sayAfter((short)100, "Alice").get();
+      //     var result2 = traits.get(1).sayAfter((short)100, "Bob").get();
 
-          assert result1.equals("Hello, Alice!");
-          assert result2.equals("Hello, Bob!");
-        });
+      //     assert result1.equals("Hello, Alice!");
+      //     assert result2.equals("Hello, Bob!");
+      //   });
 
-        assertApproximateTime(time, 200, "async trait methods");
-      }
+      //   assertApproximateTime(time, 200, "async trait methods");
+      // }
 
-      // Test async methods in UDL-defined trait interfaces
-      {
-        var traits = Futures.getSayAfterUdlTraits();
-        var time = measureTimeMillis(() -> {
-          var result1 = traits.get(0).sayAfter((short)100, "Alice").get();
-          var result2 = traits.get(1).sayAfter((short)100, "Bob").get();
+      // // Test async methods in UDL-defined trait interfaces
+      // {
+      //   var traits = Futures.getSayAfterUdlTraits();
+      //   var time = measureTimeMillis(() -> {
+      //     var result1 = traits.get(0).sayAfter((short)100, "Alice").get();
+      //     var result2 = traits.get(1).sayAfter((short)100, "Bob").get();
 
-          assert result1.equals("Hello, Alice!");
-          assert result2.equals("Hello, Bob!");
-        });
+      //     assert result1.equals("Hello, Alice!");
+      //     assert result2.equals("Hello, Bob!");
+      //   });
 
-        assertApproximateTime(time, 200, "async UDL methods");
-      }
+      //   assertApproximateTime(time, 200, "async UDL methods");
+      // }
 
       // Test foreign implemented async trait methods
       {
@@ -231,6 +231,8 @@ public class TestFixtureFutures {
         }
 
         var traitObj = new JavaAsyncParser();
+        var startingHandleCount = UniffiAsyncHelpers.uniffiForeignFutureHandleCount();
+        assert startingHandleCount == 0 : MessageFormat.format("{0} current handle count != 0", startingHandleCount);
         assert Futures.asStringUsingTrait(traitObj, 1, 42).get().equals("42");
         assert Futures.tryFromStringUsingTrait(traitObj, 1, "42").get().equals(42);
         try {
@@ -276,140 +278,140 @@ public class TestFixtureFutures {
         assert endingHandleCount == 0 : MessageFormat.format("{0} current handle count != 0", endingHandleCount);
       }
 
-      // Test with the Tokio runtime.
-      {
-        var time = measureTimeMillis(() -> {
-          var resultAlice = Futures.sayAfterWithTokio((short)200, "Alice").get();
+      // // Test with the Tokio runtime.
+      // {
+      //   var time = measureTimeMillis(() -> {
+      //     var resultAlice = Futures.sayAfterWithTokio((short)200, "Alice").get();
 
-          assert resultAlice.equals("Hello, Alice (with Tokio)!");
-        });
+      //     assert resultAlice.equals("Hello, Alice (with Tokio)!");
+      //   });
 
-        assertApproximateTime(time, 200, "with tokio runtime");
-      }
+      //   assertApproximateTime(time, 200, "with tokio runtime");
+      // }
 
-      // Test fallible function/method
-      {
-        var time1 = measureTimeMillis(() -> {
-          try {
-            Futures.fallibleMe(false).get();
-            assert true;
-          } catch (Exception e) {
-            assert false; // should never be reached
-          }
-        });
+      // // Test fallible function/method
+      // {
+      //   var time1 = measureTimeMillis(() -> {
+      //     try {
+      //       Futures.fallibleMe(false).get();
+      //       assert true;
+      //     } catch (Exception e) {
+      //       assert false; // should never be reached
+      //     }
+      //   });
 
-        System.out.print(MessageFormat.format("fallible function (with result): {0}ms", time1));
-        assert time1 < 100;
-        System.out.println(" ... ok");
+      //   System.out.print(MessageFormat.format("fallible function (with result): {0}ms", time1));
+      //   assert time1 < 100;
+      //   System.out.println(" ... ok");
 
-        var time2 = measureTimeMillis(() -> {
-          try {
-            Futures.fallibleMe(true).get();
-            assert false; // should never be reached
-          } catch (Exception e) {
-            assert true;
-          }
-        });
+      //   var time2 = measureTimeMillis(() -> {
+      //     try {
+      //       Futures.fallibleMe(true).get();
+      //       assert false; // should never be reached
+      //     } catch (Exception e) {
+      //       assert true;
+      //     }
+      //   });
 
-        System.out.print(MessageFormat.format("fallible function (with exception): {0}ms", time2));
-        assert time2 < 100;
-        System.out.println(" ... ok");
+      //   System.out.print(MessageFormat.format("fallible function (with exception): {0}ms", time2));
+      //   assert time2 < 100;
+      //   System.out.println(" ... ok");
 
-        var megaphone = Futures.newMegaphone();
+      //   var megaphone = Futures.newMegaphone();
 
-        var time3 = measureTimeMillis(() -> {
-          try {
-            megaphone.fallibleMe(false).get();
-            assert true;
-          } catch (Exception e) {
-            assert false; // should never be reached
-          }
-        });
+      //   var time3 = measureTimeMillis(() -> {
+      //     try {
+      //       megaphone.fallibleMe(false).get();
+      //       assert true;
+      //     } catch (Exception e) {
+      //       assert false; // should never be reached
+      //     }
+      //   });
 
-        System.out.print(MessageFormat.format("fallible method (with result): {0}ms", time3));
-        assert time3 < 100;
-        System.out.println(" ... ok");
+      //   System.out.print(MessageFormat.format("fallible method (with result): {0}ms", time3));
+      //   assert time3 < 100;
+      //   System.out.println(" ... ok");
         
-        var time4 = measureTimeMillis(() -> {
-          try {
-            megaphone.fallibleMe(true).get();
-            assert false; // should never be reached
-          } catch (Exception e) {
-            assert true;
-          }
-        });
+      //   var time4 = measureTimeMillis(() -> {
+      //     try {
+      //       megaphone.fallibleMe(true).get();
+      //       assert false; // should never be reached
+      //     } catch (Exception e) {
+      //       assert true;
+      //     }
+      //   });
 
-        System.out.print(MessageFormat.format("fallible method (with exception): {0}ms", time4));
-        assert time4 < 100;
-        System.out.println(" ... ok");
+      //   System.out.print(MessageFormat.format("fallible method (with exception): {0}ms", time4));
+      //   assert time4 < 100;
+      //   System.out.println(" ... ok");
 
-        Futures.fallibleStruct(false).get();
-        try {
-          Futures.fallibleStruct(true).get();
-          assert false; // should never be reached
-        } catch (Exception e) {
-          assert true;
-        }
-      }
+      //   Futures.fallibleStruct(false).get();
+      //   try {
+      //     Futures.fallibleStruct(true).get();
+      //     assert false; // should never be reached
+      //   } catch (Exception e) {
+      //     assert true;
+      //   }
+      // }
 
-      // Test record.
-      {
-        var time = measureTimeMillis(() -> {
-          var result = Futures.newMyRecord("foo", 42).get();
+      // // Test record.
+      // {
+      //   var time = measureTimeMillis(() -> {
+      //     var result = Futures.newMyRecord("foo", 42).get();
 
-          assert result.a().equals("foo");
-          assert result.b() == 42;
-        });
+      //     assert result.a().equals("foo");
+      //     assert result.b() == 42;
+      //   });
 
-        System.out.print(MessageFormat.format("record: {0}ms", time));
-        assert time < 100;
-        System.out.println(" ... ok");
-      }
+      //   System.out.print(MessageFormat.format("record: {0}ms", time));
+      //   assert time < 100;
+      //   System.out.println(" ... ok");
+      // }
 
-      // Test a broken sleep.
-      {
-        var time = measureTimeMillis(() -> {
-          Futures.brokenSleep((short)100, (short)0).get(); // calls the waker twice immediately
-          Futures.sleep((short)100).get(); // wait for possible failure
+      // // Test a broken sleep.
+      // {
+      //   var time = measureTimeMillis(() -> {
+      //     Futures.brokenSleep((short)100, (short)0).get(); // calls the waker twice immediately
+      //     Futures.sleep((short)100).get(); // wait for possible failure
 
-          Futures.brokenSleep((short)100, (short)100).get(); // calls the waker a second time after 1s
-          Futures.sleep((short)200).get(); // wait for possible failure
-        });
+      //     Futures.brokenSleep((short)100, (short)100).get(); // calls the waker a second time after 1s
+      //     Futures.sleep((short)200).get(); // wait for possible failure
+      //   });
 
-        assertApproximateTime(time, 500, "broken sleep");
-      }
+      //   assertApproximateTime(time, 500, "broken sleep");
+      // }
 
-      // Test a future that uses a lock and that is cancelled.
-      {
-        var time = measureTimeMillis(() -> {
-          var job = Futures.useSharedResource(new SharedResourceOptions((short)5000, (short)100));
+      // // Test a future that uses a lock and that is cancelled.
+      // {
+      //   var time = measureTimeMillis(() -> {
+      //     var job = Futures.useSharedResource(new SharedResourceOptions((short)5000, (short)100));
 
-          // Wait some time to ensure the task has locked the shared resource
-          TestFixtureFutures.delay(50).get();
-          // Cancel the job before the shared resource has been released.
-          job.cancel(true);
+      //     // Wait some time to ensure the task has locked the shared resource
+      //     TestFixtureFutures.delay(50).get();
+      //     // Cancel the job before the shared resource has been released.
+      //     job.cancel(true);
 
-          // Try accessing the shared resource again. The initial task should release the shared resource before the
-          // timeout expires.
-          Futures.useSharedResource(new SharedResourceOptions((short)0, (short)1000)).get();
-        });
+      //     // Try accessing the shared resource again. The initial task should release the shared resource before the
+      //     // timeout expires.
+      //     Futures.useSharedResource(new SharedResourceOptions((short)0, (short)1000)).get();
+      //   });
 
-        System.out.println(MessageFormat.format("useSharedResource: {0}ms", time));
-      }
+      //   System.out.println(MessageFormat.format("useSharedResource: {0}ms", time));
+      // }
 
-      // Test a future that uses a lock and that is not cancelled.
-      {
-        var time = measureTimeMillis(() -> {
-          // spawn both at the same time so they contend for the resource
-          var f1 = Futures.useSharedResource(new SharedResourceOptions((short)100, (short)1000));
-          var f2 = Futures.useSharedResource(new SharedResourceOptions((short)0, (short)1000));
+      // // Test a future that uses a lock and that is not cancelled.
+      // {
+      //   var time = measureTimeMillis(() -> {
+      //     // spawn both at the same time so they contend for the resource
+      //     var f1 = Futures.useSharedResource(new SharedResourceOptions((short)100, (short)1000));
+      //     var f2 = Futures.useSharedResource(new SharedResourceOptions((short)0, (short)1000));
 
-          f1.get();
-          f2.get();
-        });
+      //     f1.get();
+      //     f2.get();
+      //   });
 
-        System.out.println(MessageFormat.format("useSharedResource (not cancelled): {0}ms", time));
-      }
+      //   System.out.println(MessageFormat.format("useSharedResource (not cancelled): {0}ms", time));
+      // }
     } finally {
       // bring down the scheduler, if it's not shut down it'll hold the main thread open.
       scheduler.shutdown();

--- a/tests/scripts/TestFixtureFutures/TestFixtureFutures.java
+++ b/tests/scripts/TestFixtureFutures/TestFixtureFutures.java
@@ -263,12 +263,12 @@ public class TestFixtureFutures {
             throw e;
           }
         }
-        var completedDelaysBefore = traitObj.completedDelays;
-        Futures.cancelDelayUsingTrait(traitObj, 50).get();
-        // sleep long enough so that the `delay()` call would finish if it wasn't cancelled.
-        TestFixtureFutures.delay(200).get();
-        // If the task was cancelled, then completedDelays won't have increased
-        assert traitObj.completedDelays == completedDelaysBefore : MessageFormat.format("{0} current delays != {1} delays before", traitObj.completedDelays, completedDelaysBefore);
+        // var completedDelaysBefore = traitObj.completedDelays;
+        // Futures.cancelDelayUsingTrait(traitObj, 50).get();
+        // // sleep long enough so that the `delay()` call would finish if it wasn't cancelled.
+        // TestFixtureFutures.delay(200).get();
+        // // If the task was cancelled, then completedDelays won't have increased
+        // assert traitObj.completedDelays == completedDelaysBefore : MessageFormat.format("{0} current delays != {1} delays before", traitObj.completedDelays, completedDelaysBefore);
 
         // Test that all handles were cleaned up
         System.gc();

--- a/tests/scripts/TestFixtureFutures/TestFixtureFutures.java
+++ b/tests/scripts/TestFixtureFutures/TestFixtureFutures.java
@@ -9,6 +9,9 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
 public class TestFixtureFutures {
+  // static {
+  //     com.sun.jna.Native.setProtected(true);
+  // }
   private static final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1);
 
   // emulating Kotlin's `delay` non-blocking sleep

--- a/tests/scripts/TestFixtureFutures/TestFixtureFutures.java
+++ b/tests/scripts/TestFixtureFutures/TestFixtureFutures.java
@@ -230,39 +230,39 @@ public class TestFixtureFutures {
         }
 
         var traitObj = new JavaAsyncParser();
-        assert Futures.asStringUsingTrait(traitObj, 1, 42).get().equals("42");
-        assert Futures.tryFromStringUsingTrait(traitObj, 1, "42").get().equals(42);
-        try {
-          Futures.tryFromStringUsingTrait(traitObj, 1, "fourty-two").get();
-          throw new RuntimeException("Expected last statement to throw");
-        } catch (ExecutionException e) {
-          if (e.getCause() instanceof ParserException.NotAnInt) {
-              // Expected
-          } else {
-            throw e;
-          }
-        }
-        try {
-          Futures.tryFromStringUsingTrait(traitObj, 1, "force-unexpected-exception").get();
-          throw new RuntimeException("Expected last statement to throw");
-        } catch (ExecutionException e) {
-          if (e.getCause() instanceof ParserException.UnexpectedException) {
-             // Expected
-          } else {
-             throw e;
-          }
-        }
-        Futures.delayUsingTrait(traitObj, 1).get();
-        try {
-          Futures.tryDelayUsingTrait(traitObj, "one").get();
-          throw new RuntimeException("Expected last statement to throw");
-        } catch (ExecutionException e) {
-          if (e.getCause() instanceof ParserException.NotAnInt) {
-            // Expected
-          } else {
-            throw e;
-          }
-        }
+        // assert Futures.asStringUsingTrait(traitObj, 1, 42).get().equals("42");
+        // assert Futures.tryFromStringUsingTrait(traitObj, 1, "42").get().equals(42);
+        // try {
+        //   Futures.tryFromStringUsingTrait(traitObj, 1, "fourty-two").get();
+        //   throw new RuntimeException("Expected last statement to throw");
+        // } catch (ExecutionException e) {
+        //   if (e.getCause() instanceof ParserException.NotAnInt) {
+        //       // Expected
+        //   } else {
+        //     throw e;
+        //   }
+        // }
+        // try {
+        //   Futures.tryFromStringUsingTrait(traitObj, 1, "force-unexpected-exception").get();
+        //   throw new RuntimeException("Expected last statement to throw");
+        // } catch (ExecutionException e) {
+        //   if (e.getCause() instanceof ParserException.UnexpectedException) {
+        //      // Expected
+        //   } else {
+        //      throw e;
+        //   }
+        // }
+        // Futures.delayUsingTrait(traitObj, 1).get();
+        // try {
+        //   Futures.tryDelayUsingTrait(traitObj, "one").get();
+        //   throw new RuntimeException("Expected last statement to throw");
+        // } catch (ExecutionException e) {
+        //   if (e.getCause() instanceof ParserException.NotAnInt) {
+        //     // Expected
+        //   } else {
+        //     throw e;
+        //   }
+        // }
         var completedDelaysBefore = traitObj.completedDelays;
         Futures.cancelDelayUsingTrait(traitObj, 50).get();
         // sleep long enough so that the `delay()` call would finish if it wasn't cancelled.

--- a/tests/scripts/TestFixtureFutures/TestFixtureFutures.java
+++ b/tests/scripts/TestFixtureFutures/TestFixtureFutures.java
@@ -217,12 +217,14 @@ public class TestFixtureFutures {
 
           @Override
           public CompletableFuture<Void> tryDelay(String delayMs) {
+            System.out.println("java trait method executing" + System.currentTimeMillis());
             try {
               var parsed = Long.parseLong(delayMs);
               return TestFixtureFutures.delay(parsed).thenRun(() -> {
                 completedDelays += 1;
               });
             } catch (NumberFormatException e) {
+              System.out.println("java trait method caught exception" + System.currentTimeMillis());
               var f = new CompletableFuture<Void>();
               f.completeExceptionally(new ParserException.NotAnInt());
               return f;
@@ -256,6 +258,7 @@ public class TestFixtureFutures {
         //   }
         // }
         // Futures.delayUsingTrait(traitObj, 1).get();
+        System.out.println("calling for trait method from java test " + System.currentTimeMillis());
         try {
           Futures.tryDelayUsingTrait(traitObj, "one").get();
           throw new RuntimeException("Expected last statement to throw");
@@ -266,6 +269,7 @@ public class TestFixtureFutures {
             throw e;
           }
         }
+        System.out.println("finished trait method from java test" + System.currentTimeMillis());
         // var completedDelaysBefore = traitObj.completedDelays;
         // Futures.cancelDelayUsingTrait(traitObj, 50).get();
         // // sleep long enough so that the `delay()` call would finish if it wasn't cancelled.

--- a/tests/scripts/TestFixtureFutures/TestFixtureFutures.java
+++ b/tests/scripts/TestFixtureFutures/TestFixtureFutures.java
@@ -42,7 +42,7 @@ public class TestFixtureFutures {
 
   public static void assertReturnsImmediately(long actualTime, String testName) {
     // TODO(java): 4ms limit in Kotlin
-    assert actualTime <= 20 : MessageFormat.format("unexpected {0} time: {1}ms", testName, actualTime);
+    assert actualTime <= 40 : MessageFormat.format("unexpected {0} time: {1}ms", testName, actualTime);
   }
   
   public static void assertApproximateTime(long actualTime, int expectedTime, String testName) {

--- a/tests/scripts/TestFixtureFutures/TestFixtureFutures.java
+++ b/tests/scripts/TestFixtureFutures/TestFixtureFutures.java
@@ -252,6 +252,7 @@ public class TestFixtureFutures {
              throw e;
           }
         }
+        TestFixtureFutures.delay(5000).get();
         // Futures.delayUsingTrait(traitObj, 1).get();
         // try {
         //   Futures.tryDelayUsingTrait(traitObj, "one").get();

--- a/tests/scripts/TestFixtureFutures/TestFixtureFutures.java
+++ b/tests/scripts/TestFixtureFutures/TestFixtureFutures.java
@@ -280,7 +280,11 @@ public class TestFixtureFutures {
             emptyHandlesFuture.complete(null);
           }
         }, 0, 10, TimeUnit.MILLISECONDS);
+        try {
         emptyHandlesFuture.get(100000, TimeUnit.MILLISECONDS);
+        } catch (Exception e) {
+          // man something is so wrong
+        }
         checkHandles.cancel(true);
         var endingHandleCount = UniffiAsyncHelpers.uniffiForeignFutureHandleCount();
         assert endingHandleCount == 0 : MessageFormat.format("{0} current handle count != 0", endingHandleCount);

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -2,7 +2,7 @@
 License, v. 2.0. If a copy of the MPL was not distributed with this
 * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result, bail};
 use camino::{Utf8Path, Utf8PathBuf};
 use cargo_metadata::{MetadataCommand, Package, Target};
 use std::env::consts::ARCH;


### PR DESCRIPTION
The class we were using to cleanup foreign futures on the Java side was parameterized on the future it may need to cancel when freeing. When instantiated though instances of that class weren't being pinned anywhere, so Java was nondeterministically (and almost never locally) choosing to garbage collect them. In that case Rust would call to the memory address it had for `free` on the Java side, with the handle it wanted freed. There would be nothing listening on the Java side though and it'd silently fail.

This refactors the object pinned into the handle map to contain both the Java completable future (childFuture) and the async job that handles a response from it (calling back to Rust with the result). Then the free impl class is able to be a static singleton with no context, and is always there when Rust calls for it.

I had to extend the `immediately` timer again. I'm not sure if that's because of the additional singleton that must be loaded (unlikely) or that github was randomly slower for a bit (likely). Either way it reminded me we should really look at #25 again to improve performance. JNR may be an easy enough conversion for us to use it until JDK 25 releases in September making the new FFM (Foreign Functions and Memory) API available in an LTS.

Fixes #19 