### PR TITLE
fix: Add potential missing imports of `java.util.List` and `java.utilMap` to `OptionalTemplate`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.1
+
+- Fix `OptionalTemplate` missing potential imports of `java.util.List` and `java.util.Map`
+
 ## 0.2.0
 
 - Update to uniffi 0.29.2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1304,7 +1304,7 @@ dependencies = [
 
 [[package]]
 name = "uniffi-bindgen-java"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "askama",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniffi-bindgen-java"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["IronCore Labs <info@ironcorelabs.com>"]
 readme = "README.md"
 license = "MPL-2.0"

--- a/src/templates/OptionalTemplate.java
+++ b/src/templates/OptionalTemplate.java
@@ -2,6 +2,8 @@
 package {{ config.package_name() }};
 
 import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.Map;
 
 // public class TestForOptionals {}
 


### PR DESCRIPTION
The OptionalTemplate occasionally generates code that references java.util.Map or java.util.List.
Because the template did not add the corresponding import statements, downstream compilation fails with:

`error: cannot find symbol
  symbol:   class Map   // or List`
This PR adds these imports back