### PR TITLE
Pin IronCore workflow tags to their dotted names

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   rust-release:
-    uses: IronCoreLabs/workflows/.github/workflows/rust-release.yaml@rust-release-v2
+    uses: IronCoreLabs/workflows/.github/workflows/rust-release.yaml@rust-release-v2.0.0
     with:
       dry_run: ${{ inputs.dry_run }}
     secrets: inherit

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -9,7 +9,7 @@ name: Rust CI
   - cron: 0 14 * * 1
 jobs:
   rust-ci:
-    uses: IronCoreLabs/workflows/.github/workflows/rust-ci.yaml@rust-ci-v2
+    uses: IronCoreLabs/workflows/.github/workflows/rust-ci.yaml@rust-ci-v2.0.0
     with:
       run_clippy: true
       minimum_coverage: "0"


### PR DESCRIPTION
`IronCoreLabs/workflows` now publishes its floating tags under dotted names:
`rust-ci-v3.0.0` instead of `rust-ci-v3`. Same commit, same auto-updating
behavior — but Dependabot can parse the dotted form, so this repo will get a PR
when a workflow's next major ships.

The undotted tags are frozen and no longer move, so a repo left on them stops
receiving workflow updates entirely.

See https://github.com/IronCoreLabs/workflows/blob/main/RELEASING.md
